### PR TITLE
bugfix: 页面错误信息包含未解析的参数

### DIFF
--- a/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/exception/handler/EsbExceptionControllerAdvice.java
+++ b/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/exception/handler/EsbExceptionControllerAdvice.java
@@ -120,7 +120,7 @@ public class EsbExceptionControllerAdvice extends ExceptionControllerAdviceBase 
     ResponseEntity<?> handleInvalidParamException(HttpServletRequest request, InvalidParamException ex) {
         String errorMsg = "Handle InvalidParamException, uri: " + request.getRequestURI();
         log.warn(errorMsg, ex);
-        return new ResponseEntity<>(EsbResp.buildCommonFailResp(ex.getErrorCode()), HttpStatus.OK);
+        return new ResponseEntity<>(EsbResp.buildCommonFailResp(ex), HttpStatus.OK);
     }
 
     @ExceptionHandler(FailedPreconditionException.class)
@@ -128,7 +128,7 @@ public class EsbExceptionControllerAdvice extends ExceptionControllerAdviceBase 
     ResponseEntity<?> handleFailedPreconditionException(HttpServletRequest request, FailedPreconditionException ex) {
         String errorMsg = "Handle FailedPreconditionException, uri: " + request.getRequestURI();
         log.info(errorMsg, ex);
-        return new ResponseEntity<>(EsbResp.buildCommonFailResp(ex.getErrorCode()), HttpStatus.OK);
+        return new ResponseEntity<>(EsbResp.buildCommonFailResp(ex), HttpStatus.OK);
     }
 
     @ExceptionHandler(NotFoundException.class)
@@ -136,7 +136,7 @@ public class EsbExceptionControllerAdvice extends ExceptionControllerAdviceBase 
     ResponseEntity<?> handleNotFoundException(HttpServletRequest request, NotFoundException ex) {
         String errorMsg = "Handle NotFoundException, uri: " + request.getRequestURI();
         log.info(errorMsg, ex);
-        return new ResponseEntity<>(EsbResp.buildCommonFailResp(ex.getErrorCode()), HttpStatus.OK);
+        return new ResponseEntity<>(EsbResp.buildCommonFailResp(ex), HttpStatus.OK);
     }
 
     @ExceptionHandler(AlreadyExistsException.class)
@@ -144,7 +144,7 @@ public class EsbExceptionControllerAdvice extends ExceptionControllerAdviceBase 
     ResponseEntity<?> handleAlreadyExistsException(HttpServletRequest request, AlreadyExistsException ex) {
         String errorMsg = "Handle AlreadyExistsException, uri: " + request.getRequestURI();
         log.info(errorMsg, ex);
-        return new ResponseEntity<>(EsbResp.buildCommonFailResp(ex.getErrorCode()), HttpStatus.OK);
+        return new ResponseEntity<>(EsbResp.buildCommonFailResp(ex), HttpStatus.OK);
     }
 
     @ExceptionHandler(UnauthenticatedException.class)
@@ -152,7 +152,7 @@ public class EsbExceptionControllerAdvice extends ExceptionControllerAdviceBase 
     ResponseEntity<?> handleUnauthenticatedException(HttpServletRequest request, UnauthenticatedException ex) {
         String errorMsg = "Handle UnauthenticatedException, uri: " + request.getRequestURI();
         log.error(errorMsg, ex);
-        return new ResponseEntity<>(EsbResp.buildCommonFailResp(ex.getErrorCode()), HttpStatus.OK);
+        return new ResponseEntity<>(EsbResp.buildCommonFailResp(ex), HttpStatus.OK);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)

--- a/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/exception/handler/WebExceptionControllerAdvice.java
+++ b/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/exception/handler/WebExceptionControllerAdvice.java
@@ -102,7 +102,7 @@ public class WebExceptionControllerAdvice extends ExceptionControllerAdviceBase 
     Response<?> handleInternalException(HttpServletRequest request, InternalException ex) {
         String errorMsg = "Handle InternalException, uri: " + request.getRequestURI();
         log.error(errorMsg, ex);
-        return Response.buildCommonFailResp(ex.getErrorCode());
+        return Response.buildCommonFailResp(ex);
     }
 
     @ExceptionHandler({InvalidParamException.class})
@@ -111,7 +111,7 @@ public class WebExceptionControllerAdvice extends ExceptionControllerAdviceBase 
     Response<?> handleInvalidParamException(HttpServletRequest request, InvalidParamException ex) {
         String errorMsg = "Handle InvalidParamException, uri: " + request.getRequestURI();
         log.warn(errorMsg, ex);
-        return Response.buildCommonFailResp(ex.getErrorCode());
+        return Response.buildCommonFailResp(ex);
     }
 
     @ExceptionHandler(FailedPreconditionException.class)
@@ -120,7 +120,7 @@ public class WebExceptionControllerAdvice extends ExceptionControllerAdviceBase 
     Response<?> handleBusinessException(HttpServletRequest request, FailedPreconditionException ex) {
         String errorMsg = "Handle FailedPreconditionException, uri: " + request.getRequestURI();
         log.info(errorMsg, ex);
-        return Response.buildCommonFailResp(ex.getErrorCode());
+        return Response.buildCommonFailResp(ex);
     }
 
     @ExceptionHandler(NotFoundException.class)
@@ -129,7 +129,7 @@ public class WebExceptionControllerAdvice extends ExceptionControllerAdviceBase 
     Response<?> handleNotFoundException(HttpServletRequest request, NotFoundException ex) {
         String errorMsg = "Handle NotFoundException, uri: " + request.getRequestURI();
         log.info(errorMsg, ex);
-        return Response.buildCommonFailResp(ex.getErrorCode());
+        return Response.buildCommonFailResp(ex);
     }
 
     @ExceptionHandler(AlreadyExistsException.class)
@@ -138,7 +138,7 @@ public class WebExceptionControllerAdvice extends ExceptionControllerAdviceBase 
     Response<?> handleAlreadyExistsException(HttpServletRequest request, AlreadyExistsException ex) {
         String errorMsg = "Handle AlreadyExistsException, uri: " + request.getRequestURI();
         log.info(errorMsg, ex);
-        return Response.buildCommonFailResp(ex.getErrorCode());
+        return Response.buildCommonFailResp(ex);
     }
 
     @ExceptionHandler(UnauthenticatedException.class)
@@ -147,7 +147,7 @@ public class WebExceptionControllerAdvice extends ExceptionControllerAdviceBase 
     Response<?> handleUnauthenticatedException(HttpServletRequest request, UnauthenticatedException ex) {
         String errorMsg = "Handle UnauthenticatedException, uri: " + request.getRequestURI();
         log.error(errorMsg, ex);
-        return Response.buildCommonFailResp(ex.getErrorCode());
+        return Response.buildCommonFailResp(ex);
     }
 
     @SuppressWarnings("all")


### PR DESCRIPTION
原因：
全局异常处理代码没有正确处理好错误码的国际化，需要把错误参数也传入国际化