### PR TITLE
feature: 容器化部署job，mongodb支持sharding部署模式 #431

### DIFF
--- a/support-files/kubernetes/charts/bk-job/Chart.yaml
+++ b/support-files/kubernetes/charts/bk-job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: "bk-job"
 description: A Helm Chart for Blueking Job
 type: application
-version: 0.1.23
+version: 0.1.24
 appVersion: "3.4.2-beta.4"
 
 dependencies:

--- a/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
+++ b/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
@@ -396,11 +396,15 @@ Return the MongoDB secret name
 Return the MongoDB connect uri
 */}}
 {{- define "job.mongodb.connect.uri" -}}
-{{- $uri := (printf "mongodb://%s:%s@%s/?authSource=%s" (include "job.mongodb.username" .) (.Values.externalMongoDB.existingPasswordKey | default "mongodb-password" | printf "${%s}" ) (include "job.mongodb.hostsAndPorts" .) (include "job.mongodb.authenticationDatabase" .)) -}}
-{{- if and (not .Values.mongodb.enabled) (eq .Values.externalMongoDB.architecture "replicaset") }}
-    {{- printf "%s&replicaSet=%s" $uri .Values.externalMongoDB.replicaSetName -}}
+{{- if and (not .Values.mongodb.enabled) .Values.externalMongoDB.uri -}}
+  {{- printf "%s" .Values.externalMongoDB.uri -}}
 {{- else -}}
-    {{- printf "%s" $uri -}}
+  {{- $uri := (printf "mongodb://%s:%s@%s/?authSource=%s" (include "job.mongodb.username" .) (.Values.externalMongoDB.existingPasswordKey | default "mongodb-password" | printf "${%s}" ) (include "job.mongodb.hostsAndPorts" .) (include "job.mongodb.authenticationDatabase" .)) -}}
+  {{- if and (not .Values.mongodb.enabled) (eq .Values.externalMongoDB.architecture "replicaset") }}
+      {{- printf "%s&replicaSet=%s" $uri .Values.externalMongoDB.replicaSetName -}}
+  {{- else -}}
+      {{- printf "%s" $uri -}}
+  {{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
+++ b/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
@@ -362,7 +362,7 @@ Return the MongoDB authenticationDatabase
 {{- if .Values.mongodb.enabled }}
     {{- printf "%s" .Values.mongodb.auth.database -}}
 {{- else -}}
-    {{- printf "%s" .Values.externalMongoDB.authenticationDatabase -}}
+    {{- (.Values.externalMongoDB.authenticationDatabase | default "admin" | printf "%s" -}}
 {{- end -}}
 {{- end -}}
 

--- a/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
+++ b/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
@@ -362,7 +362,7 @@ Return the MongoDB authenticationDatabase
 {{- if .Values.mongodb.enabled }}
     {{- printf "%s" .Values.mongodb.auth.database -}}
 {{- else -}}
-    {{- (.Values.externalMongoDB.authenticationDatabase | default "admin" | printf "%s" -}}
+    {{- (.Values.externalMongoDB.authenticationDatabase | default "admin" | printf "%s" ) -}}
 {{- end -}}
 {{- end -}}
 

--- a/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
+++ b/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
@@ -398,7 +398,7 @@ Return the MongoDB connect uri
 {{- define "job.mongodb.connect.uri" -}}
 {{- $uri := (printf "mongodb://%s:%s@%s/?authSource=%s" (include "job.mongodb.username" .) (.Values.externalMongoDB.existingPasswordKey | default "mongodb-password" | printf "${%s}" ) (include "job.mongodb.hostsAndPorts" .) (include "job.mongodb.authenticationDatabase" .)) -}}
 {{- if and (not .Values.mongodb.enabled) (eq .Values.externalMongoDB.architecture "replicaset") }}
-    {{- printf "%s&replicaSet=" $uri .Values.externalMongoDB.replicaSetName -}}
+    {{- printf "%s&replicaSet=%s" $uri .Values.externalMongoDB.replicaSetName -}}
 {{- else -}}
     {{- printf "%s" $uri -}}
 {{- end -}}

--- a/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
+++ b/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
@@ -409,12 +409,12 @@ Return whether the mongodb is sharded
 */}}
 {{- define "job.mongodb.useShardingCluster" -}}
 {{- if .Values.mongodb.enabled -}}
-  {{- printf "%t" "false" -}}
+  {{- printf "%t" false -}}
 {{- else -}}
   {{- if eq "shardedCluster" .Values.externalMongoDB.architecture -}}
-    {{- printf "%t" "true" -}}
+    {{- printf "%t" true -}}
   {{- else -}}
-    {{- printf "%t" "false" -}}
+    {{- printf "%t" false -}}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
+++ b/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
@@ -396,7 +396,7 @@ Return the MongoDB secret name
 Return the MongoDB connect uri
 */}}
 {{- define "job.mongodb.connect.uri" -}}
-{{- $uri := {{- printf "mongodb://%s:%s@%s/?authSource=%s" (include "job.mongodb.username" .) (.Values.externalMongoDB.existingPasswordKey | default "mongodb-password" | printf "${%s}" ) (include "job.mongodb.hostsAndPorts" .) (include "job.mongodb.authenticationDatabase" .) -}}
+{{- $uri := (printf "mongodb://%s:%s@%s/?authSource=%s" (include "job.mongodb.username" .) (.Values.externalMongoDB.existingPasswordKey | default "mongodb-password" | printf "${%s}" ) (include "job.mongodb.hostsAndPorts" .) (include "job.mongodb.authenticationDatabase" .)) -}}
 {{- if and (not .Values.mongodb.enabled) (eq .Values.externalMongoDB.architecture "replicaset") }}
     {{- printf "%s&replicaSet=" $uri .Values.externalMongoDB.replicaSetName -}}
 {{- else -}}

--- a/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
+++ b/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
@@ -397,7 +397,7 @@ Return the MongoDB connect uri
 */}}
 {{- define "job.mongodb.connect.uri" -}}
 {{- if .Values.mongodb.enabled -}}
-  {{- printf "mongodb://%s:%s@%s/?authSource=%s" (include "job.mongodb.username" .) (printf "${%s}" "mongodb-password") (include "job.mongodb.hostsAndPorts" .) (include "job.mongodb.authenticationDatabase" .)) -}}
+  {{- printf "mongodb://%s:%s@%s/?authSource=%s" (include "job.mongodb.username" .) (printf "${%s}" "mongodb-password") (include "job.mongodb.hostsAndPorts" .) (include "job.mongodb.authenticationDatabase" .) -}}
 {{- else -}}
   {{- if .Values.externalMongoDB.uri -}}
     {{- printf "%s" .Values.externalMongoDB.uri -}}

--- a/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
+++ b/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
@@ -397,7 +397,7 @@ Return the MongoDB connect uri
 */}}
 {{- define "job.mongodb.connect.uri" -}}
 {{- if .Values.mongodb.enabled -}}
-  {{- printf "mongodb://%s:%s@%s/?authSource=%s" (include "job.mongodb.username" .) "${mongodb-password}" (include "job.mongodb.hostsAndPorts" .) (include "job.mongodb.authenticationDatabase" .)) -}}
+  {{- printf "mongodb://%s:%s@%s/?authSource=%s" (include "job.mongodb.username" .) (printf "${%s}" "mongodb-password") (include "job.mongodb.hostsAndPorts" .) (include "job.mongodb.authenticationDatabase" .)) -}}
 {{- else -}}
   {{- if .Values.externalMongoDB.uri -}}
     {{- printf "%s" .Values.externalMongoDB.uri -}}

--- a/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
+++ b/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
@@ -381,10 +381,10 @@ Return the MongoDB username
 Return the MongoDB secret name
 */}}
 {{- define "job.mongodb.secretName" -}}
-{{- if .Values.externalMongoDB.existingPasswordSecret -}}
-    {{- printf "%s" .Values.externalMongoDB.existingPasswordSecret -}}
-{{- else if .Values.mongodb.enabled }}
+{{- if .Values.mongodb.enabled -}}
     {{- printf "%s" (include "job.mongodb.fullname" .) -}}
+{{- else if .Values.externalMongoDB.existingPasswordSecret }}
+    {{- printf "%s" .Values.externalMongoDB.existingPasswordSecret -}}
 {{- else -}}
     {{- printf "%s-%s" (include "job.fullname" .) "external-mongodb" -}}
 {{- end -}}
@@ -396,14 +396,18 @@ Return the MongoDB secret name
 Return the MongoDB connect uri
 */}}
 {{- define "job.mongodb.connect.uri" -}}
-{{- if and (not .Values.mongodb.enabled) .Values.externalMongoDB.uri -}}
-  {{- printf "%s" .Values.externalMongoDB.uri -}}
+{{- if .Values.mongodb.enabled -}}
+  {{- printf "mongodb://%s:%s@%s/?authSource=%s" (include "job.mongodb.username" .) "${mongodb-password}" (include "job.mongodb.hostsAndPorts" .) (include "job.mongodb.authenticationDatabase" .)) -}}
 {{- else -}}
-  {{- $uri := (printf "mongodb://%s:%s@%s/?authSource=%s" (include "job.mongodb.username" .) (.Values.externalMongoDB.existingPasswordKey | default "mongodb-password" | printf "${%s}" ) (include "job.mongodb.hostsAndPorts" .) (include "job.mongodb.authenticationDatabase" .)) -}}
-  {{- if and (not .Values.mongodb.enabled) (eq .Values.externalMongoDB.architecture "replicaset") }}
-      {{- printf "%s&replicaSet=%s" $uri .Values.externalMongoDB.replicaSetName -}}
+  {{- if .Values.externalMongoDB.uri -}}
+    {{- printf "%s" .Values.externalMongoDB.uri -}}
   {{- else -}}
-      {{- printf "%s" $uri -}}
+    {{- $uri := (printf "mongodb://%s:%s@%s/?authSource=%s" (include "job.mongodb.username" .) (.Values.externalMongoDB.existingPasswordKey | default "mongodb-password" | printf "${%s}" ) (include "job.mongodb.hostsAndPorts" .) (include "job.mongodb.authenticationDatabase" .)) -}}
+    {{- if (eq .Values.externalMongoDB.architecture "replicaset") -}}
+        {{- printf "%s&replicaSet=%s" $uri .Values.externalMongoDB.replicaSetName -}}
+    {{- else -}}
+        {{- printf "%s" $uri -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/support-files/kubernetes/charts/bk-job/templates/job-logsvr/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-logsvr/configmap.yaml
@@ -18,6 +18,7 @@ data:
       data:
         mongodb:
           uri: {{ include "job.mongodb.connect.uri" . | quote }}
+          database: "joblog"
     job:
       logsvr:
         mongodb:

--- a/support-files/kubernetes/charts/bk-job/templates/job-logsvr/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-logsvr/configmap.yaml
@@ -17,16 +17,12 @@ data:
         name: {{ include "common.names.fullname" . }}-logsvr
       data:
         mongodb:
-          {{ if .Values.externalMongoDB.existingPasswordSecret }}
-          uri: mongodb://{{ include "job.mongodb.username" . }}:{{- .Values.externalMongoDB.existingPasswordKey | default "mongodb-password" | printf "${%s}" }}@{{- include "job.mongodb.host" . }}:{{- include "job.mongodb.port" . }}/{{- include "job.mongodb.database" . }}
-          {{- else -}}
-          uri: mongodb://{{ include "job.mongodb.username" . }}:${mongodb-password}@{{- include "job.mongodb.host" . }}:{{- include "job.mongodb.port" . }}/{{- include "job.mongodb.database" . }}
-          {{- end }}
+          uri: {{ include "job.mongodb.connect.uri" . }}
     job:
       logsvr:
         mongodb:
           shard:
-            enabled: false
+            enabled: {{ include "job.mongodb.useShardingCluster" . }}
     server:
       port: {{ .Values.logsvrConfig.containerPort }}
   {{- end}}

--- a/support-files/kubernetes/charts/bk-job/templates/job-logsvr/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-logsvr/configmap.yaml
@@ -17,7 +17,7 @@ data:
         name: {{ include "common.names.fullname" . }}-logsvr
       data:
         mongodb:
-          uri: {{ include "job.mongodb.connect.uri" . }}
+          uri: {{ include "job.mongodb.connect.uri" . | quote }}
     job:
       logsvr:
         mongodb:

--- a/support-files/kubernetes/charts/bk-job/templates/secret-externalMongoDB.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/secret-externalMongoDB.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.rabbitmq.enabled) (not .Values.externalMongoDB.existingPasswordSecret) }}
+{{- if and (not .Values.mongodb.enabled) (not .Values.externalMongoDB.existingPasswordSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -296,20 +296,50 @@ mongodb:
     database: joblog
     username: job
     password: job
+  service:
+    port: 27017
 
+## External MongoDB configuration
 ## If mongodb.enabled is false, use externalMongoDB
+## Reference documents https://docs.mongodb.com/manual/reference/connection-string/
+##
 externalMongoDB:
-  ## @param externalMongoDB.existingPasswordSecret: Existing secret with MongoDB
+  ## @param externalMongoDB.architecture  External MongoDB architecture. Allowed values: standalone/replicaset/shardedCluster
+  ##
+  architecture: ""
+  ## @param externalMongoDB.existingPasswordSecret Existing secret with MongoDB
+  ## NOTE: ignored when `externalMongoDB.uri` parameter is set
   ##
   existingPasswordSecret: ""
-  ## @param externalMongoDB.existingPasswordKey: Key in existingPasswordSecret, defaults to "mongodb-password"
+  ## @param externalMongoDB.existingPasswordKey Key in existingPasswordSecret, defaults to "mongodb-password"
+  ## NOTE: ignored when `externalMongoDB.uri` parameter is set
   ##
   existingPasswordKey: ""
-  host: ""
-  port: 27017
-  database: joblog
+  ## @param externalMongoDB.hostsAndPorts Mongo server hosts, schema: host1[:port1][,...hostN[:portN]]. for example:
+  ## hosts: "host1:27017,host2:27017"
+  ## NOTE: ignored when `externalMongoDB.uri` parameter is set
+  ##
+  hostsAndPorts: ""
+  ## @param externalMongoDB.authenticationDatabase Authentication database name
+  ## NOTE: ignored when `externalMongoDB.uri` parameter is set
+  ##
+  authenticationDatabase: "admin"
+  ## @param externalMongoDB.username Login user of the mongo server
+  ## NOTE: ignored when `externalMongoDB.uri` parameter is set
+  ##
   username: ""
+  ## @param externalMongoDB.password Login password of the mongo server
+  ## NOTE: ignored when `externalMongoDB.uri` parameter is set
+  ##
   password: ""
+  ## @param externalMongoDB.replicaSetName Required replica set name for the cluster
+  ## NOTE: ignored when `externalMongoDB.uri` parameter is set
+  ##
+  replicaSetName: ""
+  ## @param externalMongoDB.uri Mongo database URI, for example:
+  ## Reference documents https://docs.mongodb.com/manual/reference/connection-string/
+  ##
+  uri: ""
 
 nginx-ingress-controller:
   enabled: false


### PR DESCRIPTION
1. 支持mongodb standalone/replicaset/shardedCluster 模式
2. 支持外部mongodb
3. 支持两种方式配置mongodb 连接参数；同时存在的情况下，uri优先使用
```
externalMongoDB:
  ## @param externalMongoDB.existingPasswordSecret Existing secret with MongoDB
  ## NOTE: ignored when `externalMongoDB.uri` parameter is set
  ##
  existingPasswordSecret: ""
  ## @param externalMongoDB.existingPasswordKey Key in existingPasswordSecret, defaults to "mongodb-password"
  ## NOTE: ignored when `externalMongoDB.uri` parameter is set
  ##
  existingPasswordKey: ""
  ## @param externalMongoDB.hostsAndPorts Mongo server hosts, schema: host1[:port1][,...hostN[:portN]]. for example:
  ## hosts: "host1:27017,host2:27017"
  ## NOTE: ignored when `externalMongoDB.uri` parameter is set
  ##
  hostsAndPorts: ""
  ## @param externalMongoDB.authenticationDatabase Authentication database name
  ## NOTE: ignored when `externalMongoDB.uri` parameter is set
  ##
  authenticationDatabase: "admin"
  ## @param externalMongoDB.username Login user of the mongo server
  ## NOTE: ignored when `externalMongoDB.uri` parameter is set
  ##
  username: ""
  ## @param externalMongoDB.password Login password of the mongo server
  ## NOTE: ignored when `externalMongoDB.uri` parameter is set
  ##
  password: ""
  ## @param externalMongoDB.replicaSetName Required replica set name for the cluster
  ## NOTE: ignored when `externalMongoDB.uri` parameter is set
  ##
  replicaSetName: ""
```
- 直接配置uri
```
externalMongoDB:
  ## @param externalMongoDB.uri Mongo database URI, for example:
  ## Reference documents https://docs.mongodb.com/manual/reference/connection-string/
  ##
  uri: ""
```