### PR TITLE
perf: 优化JOB对异常任务的处理逻辑，减少等待时长，并正确设置任务状态

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/gse/GseClient.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/gse/GseClient.java
@@ -74,7 +74,7 @@ public class GseClient implements Closeable {
         } else {
             this.transport = new TSocket(ip, port, 60000);
         }
-        TBinaryProtocol tProtocol = new TBinaryProtocol(transport, 1024, 1024);
+        TBinaryProtocol tProtocol = new TBinaryProtocol(transport);
         this.gseAgentClient = new doSomeCmdV3.Client(tProtocol);
         if (!transport.isOpen())
             transport.open();

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/gse/GseClient.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/gse/GseClient.java
@@ -74,7 +74,7 @@ public class GseClient implements Closeable {
         } else {
             this.transport = new TSocket(ip, port, 60000);
         }
-        TBinaryProtocol tProtocol = new TBinaryProtocol(transport, 1024, -1);
+        TBinaryProtocol tProtocol = new TBinaryProtocol(transport, 1024, 1024);
         this.gseAgentClient = new doSomeCmdV3.Client(tProtocol);
         if (!transport.isOpen())
             transport.open();

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/gse/GseClient.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/gse/GseClient.java
@@ -74,8 +74,8 @@ public class GseClient implements Closeable {
         } else {
             this.transport = new TSocket(ip, port, 60000);
         }
-        TBinaryProtocol tProtocal = new TBinaryProtocol(transport);
-        this.gseAgentClient = new doSomeCmdV3.Client(tProtocal);
+        TBinaryProtocol tProtocol = new TBinaryProtocol(transport, 1024, -1);
+        this.gseAgentClient = new doSomeCmdV3.Client(tProtocol);
         if (!transport.isOpen())
             transport.open();
     }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/gse/GseRequestUtils.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/gse/GseRequestUtils.java
@@ -47,6 +47,7 @@ import com.tencent.bk.gse.taskapi.api_task_request;
 import com.tencent.bk.job.common.gse.constants.GseConstants;
 import com.tencent.bk.job.common.model.dto.IpDTO;
 import com.tencent.bk.job.common.util.ApplicationContextRegister;
+import com.tencent.bk.job.common.util.ThreadUtils;
 import com.tencent.bk.job.execute.common.exception.ReadTimeoutException;
 import com.tencent.bk.job.execute.engine.model.GseTaskResponse;
 import com.tencent.bk.job.execute.engine.model.LogPullProgress;
@@ -574,7 +575,9 @@ public class GseRequestUtils {
                 connect = true;
                 if (gseClient == null) {
                     connect = false;
-                    continue; //如果拿不到连接 ，则重试
+                    // 如果拿不到连接 ，则等待3s重试
+                    ThreadUtils.sleep(3000L);
+                    continue;
                 }
                 return caller.callback(gseClient);
             } catch (TTransportException e) {

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/AbstractResultHandleTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/AbstractResultHandleTask.java
@@ -79,7 +79,7 @@ public abstract class AbstractResultHandleTask<T> implements ContinuousScheduled
     /**
      * GSE任务超时未结束,Job最大容忍时间。5min.用于异常情况下的任务自动终止，防止长时间占用系统资源
      */
-    private static final int GSE_TASK_TIMEOUT_MAX_TOLERATION_MILLS = 60_000;
+    private static final int GSE_TASK_TIMEOUT_MAX_TOLERATION_MILLS = 300_000;
     /*
      * 同步锁
      */

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/AbstractResultHandleTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/AbstractResultHandleTask.java
@@ -299,7 +299,7 @@ public abstract class AbstractResultHandleTask<T> implements ContinuousScheduled
 
                 // 检查任务异常并处理
                 GseLog<T> gseLog = gseLogBatchPullResult.getGseLog();
-                if (checkTaskAbnormal(gseLog)) {
+                if (determineTaskAbnormal(gseLog)) {
                     return;
                 }
                 watch.stop();
@@ -383,8 +383,8 @@ public abstract class AbstractResultHandleTask<T> implements ContinuousScheduled
     /*
      * 检查任务是否异常，执行结果持续为空、超时未结束等
      */
-    private boolean checkTaskAbnormal(GseLog<?> gseLog) {
-        return checkTaskTimeout() && checkEmptyGseResult(gseLog);
+    private boolean determineTaskAbnormal(GseLog<?> gseLog) {
+        return checkTaskTimeout() || checkEmptyGseResult(gseLog);
     }
 
     private boolean checkTaskTimeout() {

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/AbstractResultHandleTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/AbstractResultHandleTask.java
@@ -79,7 +79,7 @@ public abstract class AbstractResultHandleTask<T> implements ContinuousScheduled
     /**
      * GSE任务超时未结束,Job最大容忍时间。5min.用于异常情况下的任务自动终止，防止长时间占用系统资源
      */
-    private static final int GSE_TASK_TIMEOUT_MAX_TOLERATION_MILLS = 300_000;
+    private static final int GSE_TASK_TIMEOUT_MAX_TOLERATION_MILLS = 60_000;
     /*
      * 同步锁
      */


### PR DESCRIPTION
1. 新增作业执行超时逻辑。如果执行时间超过用户设置的超时时间5min，那么设置作业状态为失败，停止任务调度
2. 优化部分日志
3. 删除AbstractResultHandleTask中对于执行结果中GseLog的errorCode的重复处理，这些已经在具体的ResultHandleTask中处理过了
4. 优化重试逻辑，获取GseClient如果失败，等待3s，而不是立即重试（一般网络问题立即重试很有可能会继续失败）