### PR TITLE
bugfix: 用户收藏执行方案场景下，执行方案分页数据总数、排序不正确 #505

### DIFF
--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/PageUtil.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/PageUtil.java
@@ -120,16 +120,16 @@ public class PageUtil {
                                             int pageSize,
                                             DbQuery<T> dbQuery) {
         boolean isExistPrioritizedElement = CollectionUtils.isNotEmpty(prioritizedElements);
-        int finalStart = start;
+        int actualStart = start;
         if (isExistPrioritizedElement && !isGetAll) {
             if (prioritizedElements.size() <= start) {
-                finalStart = start - prioritizedElements.size();
+                actualStart = start - prioritizedElements.size();
             } else {
-                finalStart = 0;
+                actualStart = 0;
             }
         }
-        PageData<T> pageData = dbQuery.query(finalStart);
-        rebuildPageData(pageData, prioritizedElements, isGetAll, isExistPrioritizedElement, finalStart, pageSize);
+        PageData<T> pageData = dbQuery.query(actualStart);
+        rebuildPageData(pageData, prioritizedElements, isGetAll, isExistPrioritizedElement, start, pageSize);
         return pageData;
     }
 

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/PageUtil.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/PageUtil.java
@@ -33,11 +33,18 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * 分页工具
+ */
 public class PageUtil {
 
-    public static final int DEFAULT_START = 0;
-    public static final int DEFAULT_POSITIVE_LENGTH = 10;
-
+    /**
+     * 标准化分页参数start与pageSize
+     *
+     * @param start    分页起始位置
+     * @param pageSize 每页大小
+     * @return 标准化分页参数
+     */
     public static Pair<Integer, Integer> normalizePageParam(Integer start, Integer pageSize) {
         if (start == null) {
             start = 0;
@@ -52,9 +59,9 @@ public class PageUtil {
     /**
      * 标准化分页参数start与pageSize
      *
-     * @param start
-     * @param pageSize
-     * @return
+     * @param start    分页起始位置
+     * @param pageSize 每页大小
+     * @return 标准化分页参数
      */
     public static Pair<Long, Long> normalizePageParam(Long start, Long pageSize) {
         Long finalStart = start;
@@ -71,11 +78,11 @@ public class PageUtil {
     /**
      * 内存中分页
      *
-     * @param completeList
-     * @param start
-     * @param pageSize
-     * @param <T>
-     * @return
+     * @param completeList 需要分页的实例列表
+     * @param start        分页起始位置
+     * @param pageSize     每页大小
+     * @param <T>          分页的实例
+     * @return 分页结果
      */
     public static <T> PageData<T> pageInMem(List<T> completeList, Integer start, Integer pageSize) {
         if (start == null || start < 0) {
@@ -107,11 +114,12 @@ public class PageUtil {
 
     /**
      * 分页查询
-     * @param isGetAll 是否全量获取
-     * @param prioritizedElements 需要优先的元素
-     * @param start 原始分页起始
-     * @param pageSize 分页大小
-     * @param dbQuery 查询
+     *
+     * @param isGetAll            是否全量获取
+     * @param prioritizedElements 需要优先的实例
+     * @param start               原始分页起始
+     * @param pageSize            分页大小
+     * @param dbQuery             查询
      * @return 分页结果
      */
     public static <T> PageData<T> pageQuery(boolean isGetAll,

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/template/impl/TaskTemplateServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/template/impl/TaskTemplateServiceImpl.java
@@ -198,16 +198,11 @@ public class TaskTemplateServiceImpl implements TaskTemplateService {
             }
         }
 
-        boolean existAnyMatchedFavoredTemplate;
         List<TaskTemplateInfoDTO> matchedFavoredTemplates = null;
         if (CollectionUtils.isNotEmpty(favoredTemplateIdList)) {
             matchedFavoredTemplates = queryFavoredTemplates(query, favoredTemplateIdList);
             query.setExcludeTemplateIds(favoredTemplateIdList);
         }
-        existAnyMatchedFavoredTemplate = CollectionUtils.isNotEmpty(matchedFavoredTemplates);
-//        if (existAnyMatchedFavoredTemplate && !getAll) {
-//            resetPageConditionWhenExistFavoredTemplate(baseSearchCondition, start, length, matchedFavoredTemplates);
-//        }
 
         PageData<TaskTemplateInfoDTO> templatePageData =
             PageUtil.pageQuery(getAll, matchedFavoredTemplates, start, length,
@@ -215,10 +210,6 @@ public class TaskTemplateServiceImpl implements TaskTemplateService {
                     query.getBaseSearchCondition().setStart(finalStart);
                     return taskTemplateDAO.listPageTaskTemplates(query);
                 });
-//        PageData<TaskTemplateInfoDTO> templatePageData = taskTemplateDAO.listPageTaskTemplates(query);
-//
-//        rebuildTemplatePageData(templatePageData, matchedFavoredTemplates, getAll, existAnyMatchedFavoredTemplate,
-//            start, length);
         setAdditionalAttributesForTemplates(query.getAppId(), templatePageData);
 
         return templatePageData;
@@ -256,60 +247,6 @@ public class TaskTemplateServiceImpl implements TaskTemplateService {
         }
         return matchedFavoredTemplates;
     }
-
-//    private void resetPageConditionWhenExistFavoredTemplate(BaseSearchCondition baseSearchCondition,
-//                                                            Integer start,
-//                                                            Integer length,
-//                                                            List<TaskTemplateInfoDTO> matchedFavoredTemplates) {
-//        if (matchedFavoredTemplates.size() <= start) {
-//            baseSearchCondition.setStart(start - matchedFavoredTemplates.size());
-//        } else {
-//            baseSearchCondition.setStart(0);
-//            baseSearchCondition.setLength(Math.max(1, start + length - matchedFavoredTemplates.size()));
-//        }
-//    }
-//
-//    private void rebuildTemplatePageData(PageData<TaskTemplateInfoDTO> templatePageData,
-//                                         List<TaskTemplateInfoDTO> matchedFavoredTemplates,
-//                                         boolean getAll,
-//                                         boolean existAnyMatchedFavoredTemplate,
-//                                         Integer start,
-//                                         Integer length) {
-//        if (existAnyMatchedFavoredTemplate) {
-//            if (getAll) {
-//                templatePageData.getData().addAll(0, matchedFavoredTemplates);
-//            } else {
-//                putFavoredTemplateInFrontIfExist(templatePageData, matchedFavoredTemplates, start, length);
-//            }
-//        }
-//
-//        if (!getAll) {
-//            templatePageData.setStart(start);
-//            templatePageData.setPageSize(length);
-//            if (existAnyMatchedFavoredTemplate) {
-//                templatePageData.setTotal(matchedFavoredTemplates.size() + templatePageData.getTotal());
-//            }
-//        }
-//    }
-//
-//    private void putFavoredTemplateInFrontIfExist(PageData<TaskTemplateInfoDTO> templatePageData,
-//                                         List<TaskTemplateInfoDTO> matchedFavoredTemplates,
-//                                         Integer start,
-//                                         Integer length) {
-//        // 前置的模板
-//        if (CollectionUtils.isNotEmpty(matchedFavoredTemplates)) {
-//            if (matchedFavoredTemplates.size() > start) {
-//                templatePageData.getData().addAll(0, matchedFavoredTemplates.stream().skip(start).limit(length)
-//                    .collect(Collectors.toList()));
-//            }
-//        }
-//
-//        // subList
-//        if (templatePageData.getData().size() > length) {
-//            List<TaskTemplateInfoDTO> templates = new ArrayList<>(templatePageData.getData().subList(0, length));
-//            templatePageData.setData(templates);
-//        }
-//    }
 
     private List<Long> queryTemplateIdsByTags(TaskTemplateQuery query) {
         List<Long> matchTemplateIds = new ArrayList<>();

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/template/impl/TaskTemplateServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/template/impl/TaskTemplateServiceImpl.java
@@ -37,6 +37,7 @@ import com.tencent.bk.job.common.model.BaseSearchCondition;
 import com.tencent.bk.job.common.model.PageData;
 import com.tencent.bk.job.common.redis.util.LockUtils;
 import com.tencent.bk.job.common.util.JobContextUtil;
+import com.tencent.bk.job.common.util.PageUtil;
 import com.tencent.bk.job.common.util.date.DateUtils;
 import com.tencent.bk.job.crontab.model.CronJobVO;
 import com.tencent.bk.job.manage.common.consts.JobResourceStatusEnum;
@@ -204,15 +205,20 @@ public class TaskTemplateServiceImpl implements TaskTemplateService {
             query.setExcludeTemplateIds(favoredTemplateIdList);
         }
         existAnyMatchedFavoredTemplate = CollectionUtils.isNotEmpty(matchedFavoredTemplates);
-        if (existAnyMatchedFavoredTemplate && !getAll) {
-            resetPageConditionWhenExistFavoredTemplate(baseSearchCondition, start, length, matchedFavoredTemplates);
-        }
+//        if (existAnyMatchedFavoredTemplate && !getAll) {
+//            resetPageConditionWhenExistFavoredTemplate(baseSearchCondition, start, length, matchedFavoredTemplates);
+//        }
 
-
-        PageData<TaskTemplateInfoDTO> templatePageData = taskTemplateDAO.listPageTaskTemplates(query);
-
-        rebuildTemplatePageData(templatePageData, matchedFavoredTemplates, getAll, existAnyMatchedFavoredTemplate,
-            start, length);
+        PageData<TaskTemplateInfoDTO> templatePageData =
+            PageUtil.pageQuery(getAll, matchedFavoredTemplates, start, length,
+                finalStart -> {
+                    query.getBaseSearchCondition().setStart(finalStart);
+                    return taskTemplateDAO.listPageTaskTemplates(query);
+                });
+//        PageData<TaskTemplateInfoDTO> templatePageData = taskTemplateDAO.listPageTaskTemplates(query);
+//
+//        rebuildTemplatePageData(templatePageData, matchedFavoredTemplates, getAll, existAnyMatchedFavoredTemplate,
+//            start, length);
         setAdditionalAttributesForTemplates(query.getAppId(), templatePageData);
 
         return templatePageData;
@@ -251,59 +257,59 @@ public class TaskTemplateServiceImpl implements TaskTemplateService {
         return matchedFavoredTemplates;
     }
 
-    private void resetPageConditionWhenExistFavoredTemplate(BaseSearchCondition baseSearchCondition,
-                                                            Integer start,
-                                                            Integer length,
-                                                            List<TaskTemplateInfoDTO> matchedFavoredTemplates) {
-        if (matchedFavoredTemplates.size() <= start) {
-            baseSearchCondition.setStart(start - matchedFavoredTemplates.size());
-        } else {
-            baseSearchCondition.setStart(0);
-            baseSearchCondition.setLength(Math.max(1, start + length - matchedFavoredTemplates.size()));
-        }
-    }
-
-    private void rebuildTemplatePageData(PageData<TaskTemplateInfoDTO> templatePageData,
-                                         List<TaskTemplateInfoDTO> matchedFavoredTemplates,
-                                         boolean getAll,
-                                         boolean existAnyMatchedFavoredTemplate,
-                                         Integer start,
-                                         Integer length) {
-        if (existAnyMatchedFavoredTemplate) {
-            if (getAll) {
-                templatePageData.getData().addAll(0, matchedFavoredTemplates);
-            } else {
-                putFavoredTemplateInFrontIfExist(templatePageData, matchedFavoredTemplates, start, length);
-            }
-        }
-
-        if (!getAll) {
-            templatePageData.setStart(start);
-            templatePageData.setPageSize(length);
-            if (existAnyMatchedFavoredTemplate) {
-                templatePageData.setTotal(matchedFavoredTemplates.size() + templatePageData.getTotal());
-            }
-        }
-    }
-
-    private void putFavoredTemplateInFrontIfExist(PageData<TaskTemplateInfoDTO> templatePageData,
-                                         List<TaskTemplateInfoDTO> matchedFavoredTemplates,
-                                         Integer start,
-                                         Integer length) {
-        // 前置的模板
-        if (CollectionUtils.isNotEmpty(matchedFavoredTemplates)) {
-            if (matchedFavoredTemplates.size() > start) {
-                templatePageData.getData().addAll(0, matchedFavoredTemplates.stream().skip(start).limit(length)
-                    .collect(Collectors.toList()));
-            }
-        }
-
-        // subList
-        if (templatePageData.getData().size() > length) {
-            List<TaskTemplateInfoDTO> templates = new ArrayList<>(templatePageData.getData().subList(0, length));
-            templatePageData.setData(templates);
-        }
-    }
+//    private void resetPageConditionWhenExistFavoredTemplate(BaseSearchCondition baseSearchCondition,
+//                                                            Integer start,
+//                                                            Integer length,
+//                                                            List<TaskTemplateInfoDTO> matchedFavoredTemplates) {
+//        if (matchedFavoredTemplates.size() <= start) {
+//            baseSearchCondition.setStart(start - matchedFavoredTemplates.size());
+//        } else {
+//            baseSearchCondition.setStart(0);
+//            baseSearchCondition.setLength(Math.max(1, start + length - matchedFavoredTemplates.size()));
+//        }
+//    }
+//
+//    private void rebuildTemplatePageData(PageData<TaskTemplateInfoDTO> templatePageData,
+//                                         List<TaskTemplateInfoDTO> matchedFavoredTemplates,
+//                                         boolean getAll,
+//                                         boolean existAnyMatchedFavoredTemplate,
+//                                         Integer start,
+//                                         Integer length) {
+//        if (existAnyMatchedFavoredTemplate) {
+//            if (getAll) {
+//                templatePageData.getData().addAll(0, matchedFavoredTemplates);
+//            } else {
+//                putFavoredTemplateInFrontIfExist(templatePageData, matchedFavoredTemplates, start, length);
+//            }
+//        }
+//
+//        if (!getAll) {
+//            templatePageData.setStart(start);
+//            templatePageData.setPageSize(length);
+//            if (existAnyMatchedFavoredTemplate) {
+//                templatePageData.setTotal(matchedFavoredTemplates.size() + templatePageData.getTotal());
+//            }
+//        }
+//    }
+//
+//    private void putFavoredTemplateInFrontIfExist(PageData<TaskTemplateInfoDTO> templatePageData,
+//                                         List<TaskTemplateInfoDTO> matchedFavoredTemplates,
+//                                         Integer start,
+//                                         Integer length) {
+//        // 前置的模板
+//        if (CollectionUtils.isNotEmpty(matchedFavoredTemplates)) {
+//            if (matchedFavoredTemplates.size() > start) {
+//                templatePageData.getData().addAll(0, matchedFavoredTemplates.stream().skip(start).limit(length)
+//                    .collect(Collectors.toList()));
+//            }
+//        }
+//
+//        // subList
+//        if (templatePageData.getData().size() > length) {
+//            List<TaskTemplateInfoDTO> templates = new ArrayList<>(templatePageData.getData().subList(0, length));
+//            templatePageData.setData(templates);
+//        }
+//    }
 
     private List<Long> queryTemplateIdsByTags(TaskTemplateQuery query) {
         List<Long> matchTemplateIds = new ArrayList<>();


### PR DESCRIPTION
1. 统一分页工具，模板查询和执行方案查询使用同一个方法
2. 修复带有优先实例列表的分页缺陷