### PR TITLE
fix: 分发第三方源文件偶现小文件MD5不正确 #521

### DIFF
--- a/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/sdk/ArtifactoryClient.java
+++ b/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/sdk/ArtifactoryClient.java
@@ -401,7 +401,8 @@ public class ArtifactoryClient {
         CloseableHttpResponse resp;
         try {
             resp = longHttpHelper.getRawResp(false, url, getJsonHeaders());
-            return Pair.of(resp.getEntity().getContent(), resp.getEntity().getContentLength());
+            return Pair.of(resp.getEntity().getContent(),
+                Long.parseLong(resp.getFirstHeader("Content-Length").getValue()));
         } catch (IOException e) {
             log.error("Fail to getFileInputStream", e);
             throw new InternalException(ErrorCode.FAIL_TO_REQUEST_THIRD_FILE_SOURCE_DOWNLOAD_GENERIC_FILE);

--- a/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/sdk/ArtifactoryClient.java
+++ b/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/sdk/ArtifactoryClient.java
@@ -61,6 +61,7 @@ import com.tencent.bk.job.common.util.json.JsonUtils;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -385,12 +386,12 @@ public class ArtifactoryClient {
         return nodeDTO;
     }
 
-    public InputStream getFileInputStream(String filePath) throws ServiceException {
+    public Pair<InputStream, Long> getFileInputStream(String filePath) throws ServiceException {
         List<String> pathList = parsePath(filePath);
         return getFileInputStream(pathList.get(0), pathList.get(1), pathList.get(2));
     }
 
-    public InputStream getFileInputStream(String projectId, String repoName, String filePath) throws ServiceException {
+    public Pair<InputStream, Long> getFileInputStream(String projectId, String repoName, String filePath) throws ServiceException {
         DownloadGenericFileReq req = new DownloadGenericFileReq();
         req.setProject(projectId);
         req.setRepo(repoName);
@@ -400,7 +401,7 @@ public class ArtifactoryClient {
         CloseableHttpResponse resp;
         try {
             resp = longHttpHelper.getRawResp(false, url, getJsonHeaders());
-            return resp.getEntity().getContent();
+            return Pair.of(resp.getEntity().getContent(), resp.getEntity().getContentLength());
         } catch (IOException e) {
             log.error("Fail to getFileInputStream", e);
             throw new InternalException(ErrorCode.FAIL_TO_REQUEST_THIRD_FILE_SOURCE_DOWNLOAD_GENERIC_FILE);

--- a/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/sdk/ArtifactoryClient.java
+++ b/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/sdk/ArtifactoryClient.java
@@ -401,8 +401,15 @@ public class ArtifactoryClient {
         CloseableHttpResponse resp;
         try {
             resp = longHttpHelper.getRawResp(false, url, getJsonHeaders());
-            return Pair.of(resp.getEntity().getContent(),
-                Long.parseLong(resp.getFirstHeader("Content-Length").getValue()));
+            Header contentLengthHeader = resp.getFirstHeader("Content-Length");
+            Long contentLength = null;
+            if (contentLengthHeader != null && StringUtils.isNotBlank(contentLengthHeader.getValue())) {
+                contentLength = Long.parseLong(contentLengthHeader.getValue());
+                log.debug("Content-Length from header:{}", contentLengthHeader.getValue());
+            } else {
+                log.debug("Content-Length from header is null or blank");
+            }
+            return Pair.of(resp.getEntity().getContent(), contentLength);
         } catch (IOException e) {
             log.error("Fail to getFileInputStream", e);
             throw new InternalException(ErrorCode.FAIL_TO_REQUEST_THIRD_FILE_SOURCE_DOWNLOAD_GENERIC_FILE);

--- a/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/sdk/ArtifactoryClient.java
+++ b/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/sdk/ArtifactoryClient.java
@@ -409,7 +409,12 @@ public class ArtifactoryClient {
             } else {
                 log.debug("Content-Length from header is null or blank");
             }
-            return Pair.of(resp.getEntity().getContent(), contentLength);
+            if (resp.getStatusLine() != null && resp.getStatusLine().getStatusCode() == 200) {
+                return Pair.of(resp.getEntity().getContent(), contentLength);
+            } else {
+                log.info("resp.statusLine={},resp.entity={}", resp.getStatusLine(), resp.getEntity());
+                throw new InternalException(ErrorCode.FAIL_TO_REQUEST_THIRD_FILE_SOURCE_DOWNLOAD_GENERIC_FILE);
+            }
         } catch (IOException e) {
             log.error("Fail to getFileInputStream", e);
             throw new InternalException(ErrorCode.FAIL_TO_REQUEST_THIRD_FILE_SOURCE_DOWNLOAD_GENERIC_FILE);

--- a/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/FileUtil.java
+++ b/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/FileUtil.java
@@ -77,6 +77,7 @@ public class FileUtil {
                 fos.write(content, 0, length);
                 Thread.sleep(0);
             }
+            closeFos(fos);
             fis = new FileInputStream(targetPath);
             return DigestUtils.md5Hex(fis);
         } catch (FileNotFoundException e) {
@@ -89,7 +90,7 @@ public class FileUtil {
             log.info("Download interrupted, targetPath:{}", targetPath);
             throw e;
         } finally {
-            closeStreams(ins, fos, fis);
+            closeStreams(ins, fis);
         }
     }
 
@@ -139,6 +140,8 @@ public class FileUtil {
                 }
                 Thread.sleep(0);
             }
+            closeFos(fos);
+            log.info("targetPath:{},totalLength={},fileSize={}", targetPath, totalLength, fileSize);
             currentSpeedWatchTime = System.currentTimeMillis();
             timeDelta = currentSpeedWatchTime - lastSpeedWatchTime;
             long fileSizeDelta = totalLength - lastSpeedWatchFileSize;
@@ -158,13 +161,23 @@ public class FileUtil {
             log.info("Download interrupted, targetPath:{}", targetPath);
             throw e;
         } finally {
-            closeStreams(ins, fos, fis);
+            closeStreams(ins, fis);
+        }
+    }
+
+    private static void closeFos(FileOutputStream fos) {
+        if (fos != null) {
+            try {
+                fos.flush();
+                fos.close();
+            } catch (IOException e) {
+                log.error("Fail to close fos", e);
+            }
         }
     }
 
     private static void closeStreams(
         InputStream ins,
-        FileOutputStream fos,
         FileInputStream fis
     ) {
         if (fis != null) {
@@ -179,14 +192,6 @@ public class FileUtil {
                 ins.close();
             } catch (IOException e) {
                 log.error("Fail to close ins", e);
-            }
-        }
-        if (fos != null) {
-            try {
-                fos.flush();
-                fos.close();
-            } catch (IOException e) {
-                log.error("Fail to close fos", e);
             }
         }
     }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/api/web/impl/WebBackupResourceImpl.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/api/web/impl/WebBackupResourceImpl.java
@@ -184,11 +184,12 @@ public class WebBackupResourceImpl implements WebBackupResource {
             throw new InternalException(ErrorCode.FAIL_TO_GET_NODE_INFO_FROM_ARTIFACTORY);
         }
         try {
-            ins = artifactoryClient.getFileInputStream(
+            Pair<InputStream, Long> pair = artifactoryClient.getFileInputStream(
                 artifactoryConfig.getArtifactoryJobProject(),
                 backupStorageConfig.getBackupRepo(),
                 fileName
             );
+            ins = pair.getLeft();
         } catch (Exception e) {
             throw new InternalException(ErrorCode.FAIL_TO_DOWNLOAD_NODE_FROM_ARTIFACTORY);
         }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/executor/ImportJobExecutor.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/executor/ImportJobExecutor.java
@@ -72,6 +72,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.stereotype.Service;
@@ -201,11 +202,12 @@ public class ImportJobExecutor {
             // 下载文件
             if (!importFileDirectory.exists()) {
                 log.debug("begin to download from artifactory:{}", importJob.getFileName());
-                InputStream ins = artifactoryClient.getFileInputStream(
+                Pair<InputStream, Long> pair = artifactoryClient.getFileInputStream(
                     artifactoryConfig.getArtifactoryJobProject(),
                     backupStorageConfig.getBackupRepo(),
                     importJob.getFileName()
                 );
+                InputStream ins = pair.getLeft();
                 String localPath = PathUtil.joinFilePath(
                     storageService.getStoragePath(),
                     importJob.getFileName()

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/web/impl/WebTaskLogResourceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/web/impl/WebTaskLogResourceImpl.java
@@ -218,11 +218,12 @@ public class WebTaskLogResourceImpl implements WebTaskLogResource {
         }
         try {
             log.debug("get {} fileInputStream from artifactory", exportInfo.getZipFileName());
-            ins = artifactoryClient.getFileInputStream(
+            Pair<InputStream, Long> pair = artifactoryClient.getFileInputStream(
                 artifactoryConfig.getArtifactoryJobProject(),
                 logExportConfig.getLogExportRepo(),
                 exportInfo.getZipFileName()
             );
+            ins = pair.getLeft();
         } catch (Exception e) {
             throw new InternalException(ErrorCode.FAIL_TO_DOWNLOAD_NODE_FROM_ARTIFACTORY);
         }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/local/ArtifactoryLocalFilePrepareTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/local/ArtifactoryLocalFilePrepareTask.java
@@ -220,16 +220,20 @@ public class ArtifactoryLocalFilePrepareTask implements JobTaskContext {
             NodeDTO nodeDTO = artifactoryClient.getFileNode(fullFilePath);
             Pair<InputStream, Long> pair = artifactoryClient.getFileInputStream(fullFilePath);
             InputStream ins = pair.getLeft();
-            long length = pair.getRight();
-            if (nodeDTO.getSize() != length) {
+            Long length = pair.getRight();
+            Long fileSize = nodeDTO.getSize();
+            if (fileSize != null && !fileSize.equals(length)) {
                 log.warn("{},ins length={},node.size={}", filePath, length, nodeDTO.getSize());
+            }
+            if (fileSize == null || fileSize <= 0) {
+                fileSize = length;
             }
             // 保存到本地临时目录
             AtomicInteger speed = new AtomicInteger(0);
             AtomicInteger process = new AtomicInteger(0);
             try {
                 log.debug("Download {} to {}", fullFilePath, localPath);
-                FileUtil.writeInsToFile(ins, localPath, length, speed, process);
+                FileUtil.writeInsToFile(ins, localPath, fileSize, speed, process);
             } catch (InterruptedException e) {
                 log.warn("Interrupted:Download {} to {}", fullFilePath, localPath);
             } catch (Exception e) {

--- a/src/backend/job-file-worker-sdk/service-job-file-worker-sdk/src/main/java/com/tencent/bk/job/file/worker/cos/service/DownloadFileTask.java
+++ b/src/backend/job-file-worker-sdk/service-job-file-worker-sdk/src/main/java/com/tencent/bk/job/file/worker/cos/service/DownloadFileTask.java
@@ -108,7 +108,7 @@ class DownloadFileTask extends Thread {
                 if (length != fileSize) {
                     log.warn("{},fileSize={},ins length={}", filePath, fileSize, length);
                 }
-                currentMd5 = FileUtil.writeInsToFile(ins, targetPath, length, speed, process);
+                currentMd5 = FileUtil.writeInsToFile(ins, targetPath, fileSize, speed, process);
                 if (fileMd5 == null) {
                     log.warn("No Md5 in metadata, do not check,key={},targetPath={},fileMd5={},currentMd5={}",
                         filePath, targetPath, fileMd5, currentMd5);

--- a/src/backend/job-file-worker-sdk/service-job-file-worker-sdk/src/main/java/com/tencent/bk/job/file/worker/cos/service/DownloadFileTask.java
+++ b/src/backend/job-file-worker-sdk/service-job-file-worker-sdk/src/main/java/com/tencent/bk/job/file/worker/cos/service/DownloadFileTask.java
@@ -32,6 +32,7 @@ import com.tencent.bk.job.common.util.file.PathUtil;
 import com.tencent.bk.job.file.worker.model.FileMetaData;
 import com.tencent.bk.job.file_gateway.consts.TaskCommandEnum;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.File;
 import java.io.IOException;
@@ -53,6 +54,7 @@ class DownloadFileTask extends Thread {
     TaskReporter taskReporter;
     DownloadFileTaskEventListener taskEventListener;
     FileProgressWatchingTask watchingTask;
+
     public DownloadFileTask(RemoteClient remoteClient, String taskId, String filePath, String downloadFileDir,
                             String filePrefix, AtomicLong fileSize, AtomicInteger speed, AtomicInteger process,
                             FileProgressWatchingTask watchingTask,
@@ -100,8 +102,13 @@ class DownloadFileTask extends Thread {
                 long fileSize = metaData.getSize();
                 fileMd5 = metaData.getMd5();
                 fileSizeWrapper.set(fileSize);
-                ins = remoteClient.getFileInputStream(filePath);
-                currentMd5 = FileUtil.writeInsToFile(ins, targetPath, fileSize, speed, process);
+                Pair<InputStream, Long> pair = remoteClient.getFileInputStream(filePath);
+                ins = pair.getLeft();
+                long length = pair.getRight();
+                if (length != fileSize) {
+                    log.warn("{},fileSize={},ins length={}", filePath, fileSize, length);
+                }
+                currentMd5 = FileUtil.writeInsToFile(ins, targetPath, length, speed, process);
                 if (fileMd5 == null) {
                     log.warn("No Md5 in metadata, do not check,key={},targetPath={},fileMd5={},currentMd5={}",
                         filePath, targetPath, fileMd5, currentMd5);

--- a/src/backend/job-file-worker-sdk/service-job-file-worker-sdk/src/main/java/com/tencent/bk/job/file/worker/cos/service/DownloadFileTask.java
+++ b/src/backend/job-file-worker-sdk/service-job-file-worker-sdk/src/main/java/com/tencent/bk/job/file/worker/cos/service/DownloadFileTask.java
@@ -104,8 +104,8 @@ class DownloadFileTask extends Thread {
                 fileSizeWrapper.set(fileSize);
                 Pair<InputStream, Long> pair = remoteClient.getFileInputStream(filePath);
                 ins = pair.getLeft();
-                long length = pair.getRight();
-                if (length != fileSize) {
+                Long length = pair.getRight();
+                if (length != null && length != fileSize) {
                     log.warn("{},fileSize={},ins length={}", filePath, fileSize, length);
                 }
                 currentMd5 = FileUtil.writeInsToFile(ins, targetPath, fileSize, speed, process);

--- a/src/backend/job-file-worker-sdk/service-job-file-worker-sdk/src/main/java/com/tencent/bk/job/file/worker/cos/service/RemoteClient.java
+++ b/src/backend/job-file-worker-sdk/service-job-file-worker-sdk/src/main/java/com/tencent/bk/job/file/worker/cos/service/RemoteClient.java
@@ -26,6 +26,7 @@ package com.tencent.bk.job.file.worker.cos.service;
 
 import com.tencent.bk.job.common.exception.ServiceException;
 import com.tencent.bk.job.file.worker.model.FileMetaData;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.InputStream;
 
@@ -33,7 +34,7 @@ public interface RemoteClient {
 
     FileMetaData getFileMetaData(String filePath);
 
-    InputStream getFileInputStream(String filePath) throws ServiceException;
+    Pair<InputStream,Long> getFileInputStream(String filePath) throws ServiceException;
 
     void shutdown();
 

--- a/src/backend/job-file-worker-sdk/service-job-file-worker-sdk/src/main/java/com/tencent/bk/job/file/worker/cos/service/RemoteClient.java
+++ b/src/backend/job-file-worker-sdk/service-job-file-worker-sdk/src/main/java/com/tencent/bk/job/file/worker/cos/service/RemoteClient.java
@@ -34,7 +34,7 @@ public interface RemoteClient {
 
     FileMetaData getFileMetaData(String filePath);
 
-    Pair<InputStream,Long> getFileInputStream(String filePath) throws ServiceException;
+    Pair<InputStream, Long> getFileInputStream(String filePath) throws ServiceException;
 
     void shutdown();
 

--- a/src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/artifactory/service/ArtifactoryRemoteClient.java
+++ b/src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/artifactory/service/ArtifactoryRemoteClient.java
@@ -31,6 +31,7 @@ import com.tencent.bk.job.file.worker.cos.service.RemoteClient;
 import com.tencent.bk.job.file.worker.model.FileMetaData;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.InputStream;
 
@@ -48,7 +49,7 @@ public class ArtifactoryRemoteClient extends ArtifactoryClient implements Remote
     }
 
     @Override
-    public InputStream getFileInputStream(String filePath) throws ServiceException {
+    public Pair<InputStream,Long> getFileInputStream(String filePath) throws ServiceException {
         return super.getFileInputStream(filePath);
     }
 

--- a/src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/artifactory/service/ArtifactoryRemoteClient.java
+++ b/src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/artifactory/service/ArtifactoryRemoteClient.java
@@ -49,7 +49,7 @@ public class ArtifactoryRemoteClient extends ArtifactoryClient implements Remote
     }
 
     @Override
-    public Pair<InputStream,Long> getFileInputStream(String filePath) throws ServiceException {
+    public Pair<InputStream, Long> getFileInputStream(String filePath) throws ServiceException {
         return super.getFileInputStream(filePath);
     }
 

--- a/src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/cos/JobTencentInnerCOSClient.java
+++ b/src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/cos/JobTencentInnerCOSClient.java
@@ -28,6 +28,7 @@ import com.tencent.bk.job.file.worker.model.FileMetaData;
 import com.tencent.cos.model.Bucket;
 import com.tencent.cos.model.COSObjectSummary;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.File;
 import java.io.InputStream;
@@ -105,7 +106,7 @@ public class JobTencentInnerCOSClient {
             key);
     }
 
-    public InputStream getFileInputStream(String bucketName, String key) {
+    public Pair<InputStream,Long> getFileInputStream(String bucketName, String key) {
         return TencentInnerCOSUtil.getFileInputStream(accessKey, secretKey, regionName, getRealBucketName(bucketName)
             , key);
     }

--- a/src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/cos/JobTencentInnerCOSClient.java
+++ b/src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/cos/JobTencentInnerCOSClient.java
@@ -106,7 +106,7 @@ public class JobTencentInnerCOSClient {
             key);
     }
 
-    public Pair<InputStream,Long> getFileInputStream(String bucketName, String key) {
+    public Pair<InputStream, Long> getFileInputStream(String bucketName, String key) {
         return TencentInnerCOSUtil.getFileInputStream(accessKey, secretKey, regionName, getRealBucketName(bucketName)
             , key);
     }

--- a/src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/cos/TencentInnerCOSUtil.java
+++ b/src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/cos/TencentInnerCOSUtil.java
@@ -44,6 +44,7 @@ import com.tencent.cos.model.ResponseHeaderOverrides;
 import com.tencent.cos.region.Region;
 import com.tencent.cos.utils.DateUtils;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -136,15 +137,15 @@ public class TencentInnerCOSUtil {
         }
     }
 
-    public static InputStream getFileInputStream(String accessKey, String secretKey, String regionName,
-                                                 String bucketName, String key) {
+    public static Pair<InputStream, Long> getFileInputStream(String accessKey, String secretKey, String regionName,
+                                                             String bucketName, String key) {
         COSClient cosClient = getCOSClient(accessKey, secretKey, regionName);
         COSObject cosObject = cosClient.getObject(bucketName, key);
         if (cosObject == null) {
             throw new InternalException(ErrorCode.FAIL_TO_REQUEST_THIRD_FILE_SOURCE_DOWNLOAD_GENERIC_FILE,
                 new String[]{String.format("Fail to getObject by bucketName %s key %s", bucketName, key)});
         }
-        return cosObject.getObjectContent();
+        return Pair.of(cosObject.getObjectContent(), cosObject.getObjectMetadata().getContentLength());
     }
 
     public static FileMetaData getFileMetaData(String accessKey, String secretKey, String regionName,

--- a/src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/cos/service/COSRemoteClient.java
+++ b/src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/cos/service/COSRemoteClient.java
@@ -57,7 +57,7 @@ public class COSRemoteClient implements RemoteClient {
     }
 
     @Override
-    public Pair<InputStream,Long> getFileInputStream(String filePath) {
+    public Pair<InputStream, Long> getFileInputStream(String filePath) {
         List<String> pathList = parsePath(filePath);
         return jobTencentInnerCOSClient.getFileInputStream(pathList.get(0), pathList.get(1));
     }

--- a/src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/cos/service/COSRemoteClient.java
+++ b/src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/cos/service/COSRemoteClient.java
@@ -26,6 +26,7 @@ package com.tencent.bk.job.file.worker.cos.service;
 
 import com.tencent.bk.job.file.worker.cos.JobTencentInnerCOSClient;
 import com.tencent.bk.job.file.worker.model.FileMetaData;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -56,7 +57,7 @@ public class COSRemoteClient implements RemoteClient {
     }
 
     @Override
-    public InputStream getFileInputStream(String filePath) {
+    public Pair<InputStream,Long> getFileInputStream(String filePath) {
         List<String> pathList = parsePath(filePath);
         return jobTencentInnerCOSClient.getFileInputStream(pathList.get(0), pathList.get(1));
     }


### PR DESCRIPTION
从文件下载请求本身获取Content-Length头作为参考，将其与MetaData中的Length进行比较，辅助定位偶现文件MD5不正确的问题。