### PR TITLE
bugfix: 批量编辑执行方案变量值导致执行方案列表未按照最后修改时间排序 #575

### DIFF
--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebTaskPlanResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebTaskPlanResourceImpl.java
@@ -44,6 +44,7 @@ import com.tencent.bk.job.common.util.check.NotEmptyChecker;
 import com.tencent.bk.job.common.util.check.StringCheckHelper;
 import com.tencent.bk.job.common.util.check.TrimChecker;
 import com.tencent.bk.job.common.util.check.exception.StringCheckException;
+import com.tencent.bk.job.common.util.date.DateUtils;
 import com.tencent.bk.job.crontab.model.CronJobVO;
 import com.tencent.bk.job.manage.api.web.WebTaskPlanResource;
 import com.tencent.bk.job.manage.common.util.IamPathUtil;
@@ -557,7 +558,7 @@ public class WebTaskPlanResourceImpl implements WebTaskPlanResource {
             return Response.buildSuccessResp(false);
         }
 
-        Long modifyTime = System.currentTimeMillis();
+        Long modifyTime = DateUtils.currentTimeSeconds();
 
         List<TaskPlanInfoDTO> planInfoList = planVariableInfoList.parallelStream().map(planVariableInfo -> {
             TaskPlanInfoDTO planInfo = new TaskPlanInfoDTO();


### PR DESCRIPTION
最后更新时间，改为秒为单位