### PR TITLE
bugfix: 模板编辑提示超时时间必须在1-86400秒之间 #598

### DIFF
--- a/support-files/sql/job-manage/0024_job_manage_20211230-1000_V3.4.4.0_mysql.sql
+++ b/support-files/sql/job-manage/0024_job_manage_20211230-1000_V3.4.4.0_mysql.sql
@@ -16,9 +16,12 @@ BEGIN
 	-- bugfix: Using second instead of millsecond
     UPDATE task_plan SET last_modify_time = last_modify_time/1000 WHERE last_modify_time > 1000000000000;
 	-- bugfix: script_timeout=0 is invalid, convert from 0 to 86400
+    UPDATE task_template_step_script SET script_timeout=86400 WHERE script_timeout=0;
     UPDATE task_plan_step_script SET script_timeout=86400 WHERE script_timeout=0;
 	-- bugfix: timeout=0 is invalid, convert from 0 to 86400
-    UPDATE task_plan_step_file SET timeout=86400 WHERE timeout=0;
+    UPDATE task_template_step_script SET script_timeout=86400 WHERE script_timeout=0;
+    UPDATE task_template_step_file SET timeout=86400 WHERE timeout=0;
+    
 	
     COMMIT;
 END <JOB_UBF>

--- a/support-files/sql/job-manage/0024_job_manage_20211230-1000_V3.4.4.0_mysql.sql
+++ b/support-files/sql/job-manage/0024_job_manage_20211230-1000_V3.4.4.0_mysql.sql
@@ -15,12 +15,12 @@ BEGIN
     
 	-- bugfix: Using second instead of millsecond
     UPDATE task_plan SET last_modify_time = last_modify_time/1000 WHERE last_modify_time > 1000000000000;
-	-- bugfix: script_timeout=0 is invalid, convert from 0 to 86400
+	-- bugfix: script step script_timeout=0 is invalid, convert from 0 to 86400
     UPDATE task_template_step_script SET script_timeout=86400 WHERE script_timeout=0;
     UPDATE task_plan_step_script SET script_timeout=86400 WHERE script_timeout=0;
-	-- bugfix: timeout=0 is invalid, convert from 0 to 86400
-    UPDATE task_template_step_script SET script_timeout=86400 WHERE script_timeout=0;
+	-- bugfix: file step timeout=0 is invalid, convert from 0 to 86400
     UPDATE task_template_step_file SET timeout=86400 WHERE timeout=0;
+	UPDATE task_plan_step_file SET script_timeout=86400 WHERE script_timeout=0;
     
 	
     COMMIT;

--- a/support-files/sql/job-manage/0024_job_manage_20211230-1000_V3.4.4.0_mysql.sql
+++ b/support-files/sql/job-manage/0024_job_manage_20211230-1000_V3.4.4.0_mysql.sql
@@ -20,7 +20,7 @@ BEGIN
     UPDATE task_plan_step_script SET script_timeout=86400 WHERE script_timeout=0;
 	-- bugfix: file step timeout=0 is invalid, convert from 0 to 86400
     UPDATE task_template_step_file SET timeout=86400 WHERE timeout=0;
-	UPDATE task_plan_step_file SET script_timeout=86400 WHERE script_timeout=0;
+	UPDATE task_plan_step_file SET timeout=86400 WHERE timeout=0;
     
 	
     COMMIT;


### PR DESCRIPTION
新增作业模板超时时间变更SQL