### PR TITLE
bugfix: Spring Cloud Config 漏洞 CVE-2020-5410 #558

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/listener/GseStepListener.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/listener/GseStepListener.java
@@ -35,7 +35,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.StreamListener;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
@@ -60,12 +59,10 @@ public class GseStepListener {
     }
 
     @StreamListener(GseTaskProcessor.INPUT)
-    public void handleMessage(@Payload StepControlMessage gseStepControlMessage,
-                              @Header("X-B3-TraceId") String traceId, @Header("X-B3-SpanId") String spanId) {
-        log.info("Receive gse step control message, stepInstanceId={}, action={}, requestId={}, msgSendTime={}, " +
-                "traceId={}, spanId={}", gseStepControlMessage.getStepInstanceId(),
-            gseStepControlMessage.getAction(), gseStepControlMessage.getRequestId(), gseStepControlMessage.getTime(),
-            traceId, spanId);
+    public void handleMessage(@Payload StepControlMessage gseStepControlMessage) {
+        log.info("Receive gse step control message, stepInstanceId={}, action={}, requestId={}, msgSendTime={}",
+            gseStepControlMessage.getStepInstanceId(), gseStepControlMessage.getAction(),
+            gseStepControlMessage.getRequestId(), gseStepControlMessage.getTime());
         long stepInstanceId = gseStepControlMessage.getStepInstanceId();
         String requestId = gseStepControlMessage.getRequestId();
         try {


### PR DESCRIPTION
- 修复升级spring cloud 版本引起的作业无法执行的问题
```
[2022-01-11 16:00:45.203][3f2249f08ed6edf1|9778e7df812e3f8b][gse.task.service.job.execute-2] ERROR o.s.i.handler.LoggingHandler:?:? - org.springframework.messaging.MessageHandlingException: Missing header 'X-B3-TraceId' for method parameter type [class java.lang.String], failedMessage=GenericMessage [payload=byte[125], headers={amqp_receivedDeliveryMode=PERSISTENT, amqp_receivedExchange=gse.task, amqp_deliveryTag=1, deliveryAttempt=3, amqp_consumerQueue=gse.task.service.job.execute, amqp_redelivered=false, amqp_receivedRoutingKey=gse.task, b3=3f2249f08ed6edf1-8f31b7f80dd102d8-0, nativeHeaders={}, amqp_timestamp=Tue Jan 11 16:00:42 CST 2022, amqp_messageId=e47b0820-d95b-97b8-b964-3af9434b4230, id=f7ff460d-7995-6d82-af21-2ee7dcd406ed, amqp_consumerTag=amq.ctag-VvRmDO6AFKhrtkvY6rUJhA, sourceData=(Body:'{"action":1,"stepInstanceId":20000000001,"time":"2022-01-11T16:00:42.191","requestId":"ad2fe5d4-2359-4b14-a0bb-b4d5e19e1d87"}' MessageProperties [headers={b3=3f2249f08ed6edf1-d0cb59465c5f9ad2-0, nativeHeaders={}}, timestamp=Tue Jan 11 16:00:42 CST 2022, messageId=e47b0820-d95b-97b8-b964-3af9434b4230, contentType=application/json, contentLength=0, receivedDeliveryMode=PERSISTENT, priority=0, redelivered=false, receivedExchange=gse.task, receivedRoutingKey=gse.task, deliveryTag=1, consumerTag=amq.ctag-VvRmDO6AFKhrtkvY6rUJhA, consumerQueue=gse.task.service.job.execute]), contentType=application/json, timestamp=1641888045201}]
```