### PR TITLE
bug: 作业执行历史归档的定时任务导致DB负载高，导致DB连接超时 #665

### DIFF
--- a/src/backend/job-backup/boot-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchivistAutoConfig.java
+++ b/src/backend/job-backup/boot-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchivistAutoConfig.java
@@ -46,9 +46,10 @@ public class ArchivistAutoConfig {
 
     @Bean(name = "execute-read-dao")
     @ConditionalOnExpression("${job.execute.archive.enabled:false} || ${job.execute.archive.delete.enabled:false}")
-    public JobExecuteDAO executeReadDAO(@Qualifier("job-execute-dsl-context") DSLContext context) {
+    public JobExecuteDAO executeReadDAO(@Qualifier("job-execute-dsl-context") DSLContext context,
+                                        ArchiveConfig archiveConfig) {
         log.info("Init JobExecuteDAO");
-        return new JobExecuteDAOImpl(context);
+        return new JobExecuteDAOImpl(context, archiveConfig);
     }
 
     @Bean(name = "execute-archive-dao")

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractArchivist.java
@@ -273,7 +273,7 @@ public abstract class AbstractArchivist<T extends TableRecord<?>> {
                 lastDeletedId = stop;
                 deletedRows += deleteCount;
                 start += deleteIdStepSize;
-                log.info("Batch delete {}, lastDeletedId: {}, delete rows: {}, cost: {}ms", tableName,
+                log.info("Delete {}, lastDeletedId: {}, delete rows: {}, cost: {}ms", tableName,
                     lastDeletedId, deleteCount, System.currentTimeMillis() - batchDeleteStartTime);
                 updateDeleteProgress(lastDeletedId);
             }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchiveConfig.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchiveConfig.java
@@ -49,4 +49,7 @@ public class ArchiveConfig {
 
     @Value("${job.execute.archive.delete.enabled:false}")
     private boolean deleteEnabled;
+
+    @Value("${job.execute.archive.delete.limit_row_count:5000}")
+    private Integer deleteLimitRowCount;
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchiveConfig.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchiveConfig.java
@@ -50,6 +50,6 @@ public class ArchiveConfig {
     @Value("${job.execute.archive.delete.enabled:false}")
     private boolean deleteEnabled;
 
-    @Value("${job.execute.archive.delete.limit_row_count:5000}")
+    @Value("${job.execute.archive.delete.limit-row-count:5000}")
     private Integer deleteLimitRowCount;
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/ExecuteArchiveDAOImpl.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/ExecuteArchiveDAOImpl.java
@@ -63,8 +63,7 @@ public class ExecuteArchiveDAOImpl implements ExecuteArchiveDAO {
         try {
             Loader<?> loader =
                 context.loadInto(recordList.get(0).getTable())
-                    .onDuplicateKeyIgnore()
-                    .onErrorAbort()
+                    .onErrorIgnore()
                     .bulkAfter(bulkSize)
                     .loadRecords(recordList)
                     .fields(fieldList)

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/ExecuteArchiveDAOImpl.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/ExecuteArchiveDAOImpl.java
@@ -66,7 +66,7 @@ public class ExecuteArchiveDAOImpl implements ExecuteArchiveDAO {
                     .onErrorIgnore()
                     .bulkAfter(bulkSize)
                     .loadRecords(recordList)
-                    .fieldsCorresponding()
+                    .fields(fieldList)
                     .execute();
             executeResult = loader.stored();
             log.info("Load {} data result|executed|{}|processed|{}|stored|{}|ignored|{}|errors|{}", table,

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/ExecuteArchiveDAOImpl.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/ExecuteArchiveDAOImpl.java
@@ -27,7 +27,11 @@ package com.tencent.bk.job.backup.dao.impl;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.jooq.*;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.Loader;
+import org.jooq.LoaderError;
+import org.jooq.TableRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +66,7 @@ public class ExecuteArchiveDAOImpl implements ExecuteArchiveDAO {
                     .onErrorIgnore()
                     .bulkAfter(bulkSize)
                     .loadRecords(recordList)
-                    .fields(fieldList)
+                    .fieldsCorresponding()
                     .execute();
             executeResult = loader.stored();
             log.info("Load {} data result|executed|{}|processed|{}|stored|{}|ignored|{}|errors|{}", table,

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/ExecuteArchiveDAOImpl.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/ExecuteArchiveDAOImpl.java
@@ -63,7 +63,8 @@ public class ExecuteArchiveDAOImpl implements ExecuteArchiveDAO {
         try {
             Loader<?> loader =
                 context.loadInto(recordList.get(0).getTable())
-                    .onErrorIgnore()
+                    .onDuplicateKeyIgnore()
+                    .onErrorAbort()
                     .bulkAfter(bulkSize)
                     .loadRecords(recordList)
                     .fields(fieldList)

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/JobExecuteDAOImpl.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/JobExecuteDAOImpl.java
@@ -26,9 +26,36 @@ package com.tencent.bk.job.backup.dao.impl;
 
 import com.tencent.bk.job.backup.dao.JobExecuteDAO;
 import lombok.extern.slf4j.Slf4j;
-import org.jooq.*;
-import org.jooq.generated.tables.*;
-import org.jooq.generated.tables.records.*;
+import org.jooq.Condition;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.Record1;
+import org.jooq.Result;
+import org.jooq.Table;
+import org.jooq.TableField;
+import org.jooq.generated.tables.FileSourceTaskLog;
+import org.jooq.generated.tables.GseTaskIpLog;
+import org.jooq.generated.tables.GseTaskLog;
+import org.jooq.generated.tables.OperationLog;
+import org.jooq.generated.tables.StepInstance;
+import org.jooq.generated.tables.StepInstanceConfirm;
+import org.jooq.generated.tables.StepInstanceFile;
+import org.jooq.generated.tables.StepInstanceScript;
+import org.jooq.generated.tables.StepInstanceVariable;
+import org.jooq.generated.tables.TaskInstance;
+import org.jooq.generated.tables.TaskInstanceVariable;
+import org.jooq.generated.tables.records.FileSourceTaskLogRecord;
+import org.jooq.generated.tables.records.GseTaskIpLogRecord;
+import org.jooq.generated.tables.records.GseTaskLogRecord;
+import org.jooq.generated.tables.records.OperationLogRecord;
+import org.jooq.generated.tables.records.StepInstanceConfirmRecord;
+import org.jooq.generated.tables.records.StepInstanceFileRecord;
+import org.jooq.generated.tables.records.StepInstanceRecord;
+import org.jooq.generated.tables.records.StepInstanceScriptRecord;
+import org.jooq.generated.tables.records.StepInstanceVariableRecord;
+import org.jooq.generated.tables.records.TaskInstanceRecord;
+import org.jooq.generated.tables.records.TaskInstanceVariableRecord;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -90,39 +117,39 @@ public class JobExecuteDAOImpl implements JobExecuteDAO {
     private static final StepInstanceConfirm STEP_INSTANCE_CONFIRM_TABLE = StepInstanceConfirm.STEP_INSTANCE_CONFIRM;
     private static final List<Field<?>> STEP_INSTANCE_CONFIRM_FIELDS =
         Arrays.asList(STEP_INSTANCE_CONFIRM_TABLE.STEP_INSTANCE_ID, STEP_INSTANCE_CONFIRM_TABLE.CONFIRM_MESSAGE,
-        STEP_INSTANCE_CONFIRM_TABLE.CONFIRM_USERS, STEP_INSTANCE_CONFIRM_TABLE.CONFIRM_ROLES,
-        STEP_INSTANCE_CONFIRM_TABLE.NOTIFY_CHANNELS, STEP_INSTANCE_CONFIRM_TABLE.ROW_CREATE_TIME,
-        STEP_INSTANCE_CONFIRM_TABLE.ROW_UPDATE_TIME, STEP_INSTANCE_CONFIRM_TABLE.CONFIRM_REASON);
+            STEP_INSTANCE_CONFIRM_TABLE.CONFIRM_USERS, STEP_INSTANCE_CONFIRM_TABLE.CONFIRM_ROLES,
+            STEP_INSTANCE_CONFIRM_TABLE.NOTIFY_CHANNELS, STEP_INSTANCE_CONFIRM_TABLE.ROW_CREATE_TIME,
+            STEP_INSTANCE_CONFIRM_TABLE.ROW_UPDATE_TIME, STEP_INSTANCE_CONFIRM_TABLE.CONFIRM_REASON);
 
     private static final StepInstanceFile STEP_INSTANCE_FILE_TABLE = StepInstanceFile.STEP_INSTANCE_FILE;
     private static final List<Field<?>> STEP_INSTANCE_FILE_FIELDS =
         Arrays.asList(STEP_INSTANCE_FILE_TABLE.STEP_INSTANCE_ID, STEP_INSTANCE_FILE_TABLE.FILE_SOURCE,
-        STEP_INSTANCE_FILE_TABLE.RESOLVED_FILE_SOURCE, STEP_INSTANCE_FILE_TABLE.FILE_TARGET_PATH,
-        STEP_INSTANCE_FILE_TABLE.RESOLVED_FILE_TARGET_PATH, STEP_INSTANCE_FILE_TABLE.FILE_UPLOAD_SPEED_LIMIT,
-        STEP_INSTANCE_FILE_TABLE.FILE_DOWNLOAD_SPEED_LIMIT, STEP_INSTANCE_FILE_TABLE.FILE_DUPLICATE_HANDLE,
-        STEP_INSTANCE_FILE_TABLE.NOT_EXIST_PATH_HANDLER, STEP_INSTANCE_FILE_TABLE.EXECUTION_TIMEOUT,
-        STEP_INSTANCE_FILE_TABLE.SYSTEM_ACCOUNT_ID, STEP_INSTANCE_FILE_TABLE.SYSTEM_ACCOUNT,
-        STEP_INSTANCE_FILE_TABLE.ROW_CREATE_TIME, STEP_INSTANCE_FILE_TABLE.ROW_UPDATE_TIME);
+            STEP_INSTANCE_FILE_TABLE.RESOLVED_FILE_SOURCE, STEP_INSTANCE_FILE_TABLE.FILE_TARGET_PATH,
+            STEP_INSTANCE_FILE_TABLE.RESOLVED_FILE_TARGET_PATH, STEP_INSTANCE_FILE_TABLE.FILE_UPLOAD_SPEED_LIMIT,
+            STEP_INSTANCE_FILE_TABLE.FILE_DOWNLOAD_SPEED_LIMIT, STEP_INSTANCE_FILE_TABLE.FILE_DUPLICATE_HANDLE,
+            STEP_INSTANCE_FILE_TABLE.NOT_EXIST_PATH_HANDLER, STEP_INSTANCE_FILE_TABLE.EXECUTION_TIMEOUT,
+            STEP_INSTANCE_FILE_TABLE.SYSTEM_ACCOUNT_ID, STEP_INSTANCE_FILE_TABLE.SYSTEM_ACCOUNT,
+            STEP_INSTANCE_FILE_TABLE.ROW_CREATE_TIME, STEP_INSTANCE_FILE_TABLE.ROW_UPDATE_TIME);
 
     private static final StepInstanceScript STEP_INSTANCE_SCRIPT_TABLE = StepInstanceScript.STEP_INSTANCE_SCRIPT;
     private static final List<Field<?>> STEP_INSTANCE_SCRIPT_FIELDS =
         Arrays.asList(STEP_INSTANCE_SCRIPT_TABLE.STEP_INSTANCE_ID, STEP_INSTANCE_SCRIPT_TABLE.SCRIPT_CONTENT,
-        STEP_INSTANCE_SCRIPT_TABLE.SCRIPT_TYPE, STEP_INSTANCE_SCRIPT_TABLE.SCRIPT_PARAM,
-        STEP_INSTANCE_SCRIPT_TABLE.RESOLVED_SCRIPT_PARAM, STEP_INSTANCE_SCRIPT_TABLE.EXECUTION_TIMEOUT,
-        STEP_INSTANCE_SCRIPT_TABLE.SYSTEM_ACCOUNT_ID, STEP_INSTANCE_SCRIPT_TABLE.SYSTEM_ACCOUNT,
-        STEP_INSTANCE_SCRIPT_TABLE.DB_ACCOUNT_ID, STEP_INSTANCE_SCRIPT_TABLE.DB_TYPE,
-        STEP_INSTANCE_SCRIPT_TABLE.DB_ACCOUNT, STEP_INSTANCE_SCRIPT_TABLE.DB_PASSWORD,
-        STEP_INSTANCE_SCRIPT_TABLE.DB_PORT, STEP_INSTANCE_SCRIPT_TABLE.ROW_CREATE_TIME,
-        STEP_INSTANCE_SCRIPT_TABLE.ROW_UPDATE_TIME, STEP_INSTANCE_SCRIPT_TABLE.SCRIPT_SOURCE,
-        STEP_INSTANCE_SCRIPT_TABLE.SCRIPT_ID, STEP_INSTANCE_SCRIPT_TABLE.SCRIPT_VERSION_ID,
-        STEP_INSTANCE_SCRIPT_TABLE.IS_SECURE_PARAM);
+            STEP_INSTANCE_SCRIPT_TABLE.SCRIPT_TYPE, STEP_INSTANCE_SCRIPT_TABLE.SCRIPT_PARAM,
+            STEP_INSTANCE_SCRIPT_TABLE.RESOLVED_SCRIPT_PARAM, STEP_INSTANCE_SCRIPT_TABLE.EXECUTION_TIMEOUT,
+            STEP_INSTANCE_SCRIPT_TABLE.SYSTEM_ACCOUNT_ID, STEP_INSTANCE_SCRIPT_TABLE.SYSTEM_ACCOUNT,
+            STEP_INSTANCE_SCRIPT_TABLE.DB_ACCOUNT_ID, STEP_INSTANCE_SCRIPT_TABLE.DB_TYPE,
+            STEP_INSTANCE_SCRIPT_TABLE.DB_ACCOUNT, STEP_INSTANCE_SCRIPT_TABLE.DB_PASSWORD,
+            STEP_INSTANCE_SCRIPT_TABLE.DB_PORT, STEP_INSTANCE_SCRIPT_TABLE.ROW_CREATE_TIME,
+            STEP_INSTANCE_SCRIPT_TABLE.ROW_UPDATE_TIME, STEP_INSTANCE_SCRIPT_TABLE.SCRIPT_SOURCE,
+            STEP_INSTANCE_SCRIPT_TABLE.SCRIPT_ID, STEP_INSTANCE_SCRIPT_TABLE.SCRIPT_VERSION_ID,
+            STEP_INSTANCE_SCRIPT_TABLE.IS_SECURE_PARAM);
 
     private static final StepInstanceVariable STEP_INSTANCE_VARIABLE_TABLE =
         StepInstanceVariable.STEP_INSTANCE_VARIABLE;
     private static final List<Field<?>> STEP_INSTANCE_VARIABLE_FIELDS =
         Arrays.asList(STEP_INSTANCE_VARIABLE_TABLE.TASK_INSTANCE_ID, STEP_INSTANCE_VARIABLE_TABLE.STEP_INSTANCE_ID,
-        STEP_INSTANCE_VARIABLE_TABLE.TYPE, STEP_INSTANCE_VARIABLE_TABLE.PARAM_VALUES,
-        STEP_INSTANCE_VARIABLE_TABLE.ROW_CREATE_TIME, STEP_INSTANCE_VARIABLE_TABLE.ROW_UPDATE_TIME);
+            STEP_INSTANCE_VARIABLE_TABLE.TYPE, STEP_INSTANCE_VARIABLE_TABLE.PARAM_VALUES,
+            STEP_INSTANCE_VARIABLE_TABLE.ROW_CREATE_TIME, STEP_INSTANCE_VARIABLE_TABLE.ROW_UPDATE_TIME);
     private static final TaskInstance TASK_INSTANCE_TABLE = TaskInstance.TASK_INSTANCE;
     private static final List<Field<?>> TASK_INSTANCE_FIELDS = Arrays.asList(TASK_INSTANCE_TABLE.ID,
         TASK_INSTANCE_TABLE.APP_ID, TASK_INSTANCE_TABLE.TASK_ID,
@@ -412,7 +439,7 @@ public class JobExecuteDAOImpl implements JobExecuteDAO {
         List<Condition> conditions = new ArrayList<>();
         conditions.add(FILE_SOURCE_TASK_LOG_TABLE.STEP_INSTANCE_ID.greaterThan(start));
         conditions.add(FILE_SOURCE_TASK_LOG_TABLE.STEP_INSTANCE_ID.lessOrEqual(stop));
-        return context.delete(FILE_SOURCE_TASK_LOG_TABLE).where(conditions).execute();
+        return deleteWithLimit(FILE_SOURCE_TASK_LOG_TABLE, conditions);
     }
 
     @Override
@@ -420,7 +447,20 @@ public class JobExecuteDAOImpl implements JobExecuteDAO {
         List<Condition> conditions = new ArrayList<>();
         conditions.add(GSE_TASK_IP_LOG_TABLE.STEP_INSTANCE_ID.greaterThan(start));
         conditions.add(GSE_TASK_IP_LOG_TABLE.STEP_INSTANCE_ID.lessOrEqual(stop));
-        return context.delete(GSE_TASK_IP_LOG_TABLE).where(conditions).execute();
+        return deleteWithLimit(GSE_TASK_IP_LOG_TABLE, conditions);
+    }
+
+    private int deleteWithLimit(Table<? extends Record> table, List<Condition> conditions) {
+        int totalDeleteRows = 0;
+        int maxLimitedDeleteRows = 2000;
+        while (true) {
+            int deletedRows = context.delete(table).where(conditions).limit(maxLimitedDeleteRows).execute();
+            totalDeleteRows += deletedRows;
+            if (deletedRows < maxLimitedDeleteRows) {
+                break;
+            }
+        }
+        return totalDeleteRows;
     }
 
     @Override
@@ -428,7 +468,7 @@ public class JobExecuteDAOImpl implements JobExecuteDAO {
         List<Condition> conditions = new ArrayList<>();
         conditions.add(GSE_TASK_LOG_TABLE.STEP_INSTANCE_ID.greaterThan(start));
         conditions.add(GSE_TASK_LOG_TABLE.STEP_INSTANCE_ID.lessOrEqual(stop));
-        return context.delete(GSE_TASK_LOG_TABLE).where(conditions).execute();
+        return deleteWithLimit(GSE_TASK_LOG_TABLE, conditions);
     }
 
     @Override
@@ -436,7 +476,7 @@ public class JobExecuteDAOImpl implements JobExecuteDAO {
         List<Condition> conditions = new ArrayList<>();
         conditions.add(OPERATION_LOG_TABLE.TASK_INSTANCE_ID.greaterThan(start));
         conditions.add(OPERATION_LOG_TABLE.TASK_INSTANCE_ID.lessOrEqual(stop));
-        return context.delete(OPERATION_LOG_TABLE).where(conditions).execute();
+        return deleteWithLimit(OPERATION_LOG_TABLE, conditions);
     }
 
     @Override
@@ -444,7 +484,7 @@ public class JobExecuteDAOImpl implements JobExecuteDAO {
         List<Condition> conditions = new ArrayList<>();
         conditions.add(STEP_INSTANCE_TABLE.ID.greaterThan(start));
         conditions.add(STEP_INSTANCE_TABLE.ID.lessOrEqual(stop));
-        return context.delete(STEP_INSTANCE_TABLE).where(conditions).execute();
+        return deleteWithLimit(STEP_INSTANCE_TABLE, conditions);
     }
 
     @Override
@@ -452,7 +492,7 @@ public class JobExecuteDAOImpl implements JobExecuteDAO {
         List<Condition> conditions = new ArrayList<>();
         conditions.add(STEP_INSTANCE_CONFIRM_TABLE.STEP_INSTANCE_ID.greaterThan(start));
         conditions.add(STEP_INSTANCE_CONFIRM_TABLE.STEP_INSTANCE_ID.lessOrEqual(stop));
-        return context.delete(STEP_INSTANCE_CONFIRM_TABLE).where(conditions).execute();
+        return deleteWithLimit(STEP_INSTANCE_CONFIRM_TABLE, conditions);
     }
 
     @Override
@@ -460,7 +500,7 @@ public class JobExecuteDAOImpl implements JobExecuteDAO {
         List<Condition> conditions = new ArrayList<>();
         conditions.add(STEP_INSTANCE_FILE_TABLE.STEP_INSTANCE_ID.greaterThan(start));
         conditions.add(STEP_INSTANCE_FILE_TABLE.STEP_INSTANCE_ID.lessOrEqual(stop));
-        return context.delete(STEP_INSTANCE_FILE_TABLE).where(conditions).execute();
+        return deleteWithLimit(STEP_INSTANCE_FILE_TABLE, conditions);
     }
 
     @Override
@@ -468,7 +508,7 @@ public class JobExecuteDAOImpl implements JobExecuteDAO {
         List<Condition> conditions = new ArrayList<>();
         conditions.add(STEP_INSTANCE_SCRIPT_TABLE.STEP_INSTANCE_ID.greaterThan(start));
         conditions.add(STEP_INSTANCE_SCRIPT_TABLE.STEP_INSTANCE_ID.lessOrEqual(stop));
-        return context.delete(STEP_INSTANCE_SCRIPT_TABLE).where(conditions).execute();
+        return deleteWithLimit(STEP_INSTANCE_SCRIPT_TABLE, conditions);
     }
 
     @Override
@@ -476,7 +516,7 @@ public class JobExecuteDAOImpl implements JobExecuteDAO {
         List<Condition> conditions = new ArrayList<>();
         conditions.add(STEP_INSTANCE_VARIABLE_TABLE.STEP_INSTANCE_ID.greaterThan(start));
         conditions.add(STEP_INSTANCE_VARIABLE_TABLE.STEP_INSTANCE_ID.lessOrEqual(stop));
-        return context.delete(STEP_INSTANCE_VARIABLE_TABLE).where(conditions).execute();
+        return deleteWithLimit(STEP_INSTANCE_VARIABLE_TABLE, conditions);
     }
 
     @Override
@@ -484,7 +524,7 @@ public class JobExecuteDAOImpl implements JobExecuteDAO {
         List<Condition> conditions = new ArrayList<>();
         conditions.add(TASK_INSTANCE_TABLE.ID.greaterThan(start));
         conditions.add(TASK_INSTANCE_TABLE.ID.lessOrEqual(stop));
-        return context.delete(TASK_INSTANCE_TABLE).where(conditions).execute();
+        return deleteWithLimit(TASK_INSTANCE_TABLE, conditions);
     }
 
     @Override
@@ -492,6 +532,6 @@ public class JobExecuteDAOImpl implements JobExecuteDAO {
         List<Condition> conditions = new ArrayList<>();
         conditions.add(TASK_INSTANCE_VARIABLE_TABLE.TASK_INSTANCE_ID.greaterThan(start));
         conditions.add(TASK_INSTANCE_VARIABLE_TABLE.TASK_INSTANCE_ID.lessOrEqual(stop));
-        return context.delete(TASK_INSTANCE_VARIABLE_TABLE).where(conditions).execute();
+        return deleteWithLimit(TASK_INSTANCE_VARIABLE_TABLE, conditions);
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/JobExecuteDAOImpl.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/JobExecuteDAOImpl.java
@@ -452,7 +452,7 @@ public class JobExecuteDAOImpl implements JobExecuteDAO {
 
     private int deleteWithLimit(Table<? extends Record> table, List<Condition> conditions) {
         int totalDeleteRows = 0;
-        int maxLimitedDeleteRows = 2000;
+        int maxLimitedDeleteRows = 5000;
         while (true) {
             int deletedRows = context.delete(table).where(conditions).limit(maxLimitedDeleteRows).execute();
             totalDeleteRows += deletedRows;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/JobExecuteDAOImpl.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/JobExecuteDAOImpl.java
@@ -24,6 +24,7 @@
 
 package com.tencent.bk.job.backup.dao.impl;
 
+import com.tencent.bk.job.backup.config.ArchiveConfig;
 import com.tencent.bk.job.backup.dao.JobExecuteDAO;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.Condition;
@@ -167,11 +168,14 @@ public class JobExecuteDAOImpl implements JobExecuteDAO {
         TASK_INSTANCE_VARIABLE_TABLE.NAME, TASK_INSTANCE_VARIABLE_TABLE.TYPE,
         TASK_INSTANCE_VARIABLE_TABLE.VALUE, TASK_INSTANCE_VARIABLE_TABLE.IS_CHANGEABLE,
         TASK_INSTANCE_VARIABLE_TABLE.ROW_CREATE_TIME, TASK_INSTANCE_VARIABLE_TABLE.ROW_UPDATE_TIME);
-    private final DSLContext context;
 
-    public JobExecuteDAOImpl(DSLContext context) {
+    private final DSLContext context;
+    private final ArchiveConfig archiveConfig;
+
+    public JobExecuteDAOImpl(DSLContext context, ArchiveConfig archiveConfig) {
         log.info("Init ExecuteReadDAO.");
         this.context = context;
+        this.archiveConfig = archiveConfig;
     }
 
     @Override
@@ -452,7 +456,7 @@ public class JobExecuteDAOImpl implements JobExecuteDAO {
 
     private int deleteWithLimit(Table<? extends Record> table, List<Condition> conditions) {
         int totalDeleteRows = 0;
-        int maxLimitedDeleteRows = 5000;
+        int maxLimitedDeleteRows = archiveConfig.getDeleteLimitRowCount();
         while (true) {
             int deletedRows = context.delete(table).where(conditions).limit(maxLimitedDeleteRows).execute();
             totalDeleteRows += deletedRows;


### PR DESCRIPTION
1. 一次最多删除5000行
2. 解决归档任务未获取到分布式锁ID，但是会释放锁的问题