### PR TITLE
feature: 业务集支持灰度启用 #946

### DIFF
--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/config/FeatureToggleConfig.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/config/FeatureToggleConfig.java
@@ -54,9 +54,22 @@ public class FeatureToggleConfig {
     @Getter
     @Setter
     public static class ToggleConfig {
+        /**
+         * 特性开关是否开启
+         */
         private boolean enabled = true;
+        /**
+         * 是否支持灰度开启
+         */
         private boolean gray;
-        private List<Long> grayApps;
+        /**
+         * 按灰度业务，生效的业务,gray=true条件下该参数生效
+         */
+        private List<Long> includeApps;
+        /**
+         * 按业务灰度，排除掉的业务,gray=true的条件下该参数生效
+         */
+        private List<Long> excludeApps;
     }
 
     @PostConstruct

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/config/FeatureToggleConfig.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/config/FeatureToggleConfig.java
@@ -29,6 +29,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import javax.annotation.PostConstruct;
@@ -50,8 +51,10 @@ public class FeatureToggleConfig {
     private ToggleConfig esbApiParamBkBizId = new ToggleConfig();
 
 
+    /**
+     * 特性开关配置
+     */
     @ToString
-    @Getter
     @Setter
     public static class ToggleConfig {
         /**
@@ -59,17 +62,45 @@ public class FeatureToggleConfig {
          */
         private boolean enabled = true;
         /**
-         * 是否支持灰度开启
+         * 是否支持灰度
          */
         private boolean gray;
         /**
-         * 按灰度业务，生效的业务,gray=true条件下该参数生效
+         * 灰度-白名单
          */
-        private List<Long> includeApps;
+        private List<String> include;
         /**
-         * 按业务灰度，排除掉的业务,gray=true的条件下该参数生效
+         * 灰度-黑名单
          */
-        private List<Long> excludeApps;
+        private List<String> exclude;
+
+        /**
+         * 判断是否开启特性 - 灰度
+         */
+        public boolean isOpen(String value) {
+            if (!enabled) {
+                // 特性开关未开启
+                return false;
+            }
+            if (!gray) {
+                // 未开启灰度，全量开启
+                return true;
+            }
+            // 如果配置exclude参数，需要优先判断灰度黑名单
+            if (CollectionUtils.isNotEmpty(exclude) && exclude.contains(value)) {
+                return false;
+            }
+            // 是否在灰度白名单中
+            return CollectionUtils.isNotEmpty(include) && include.contains(value);
+        }
+
+        /**
+         * 判断是否开启特性
+         */
+        public boolean isOpen() {
+            return enabled;
+        }
+
     }
 
     @PostConstruct

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/feature/FeatureToggle.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/feature/FeatureToggle.java
@@ -26,7 +26,6 @@ package com.tencent.bk.job.common.util.feature;
 
 import com.tencent.bk.job.common.config.FeatureToggleConfig;
 import com.tencent.bk.job.common.util.ApplicationContextRegister;
-import org.apache.commons.collections4.CollectionUtils;
 
 /**
  * 特性开关
@@ -46,28 +45,24 @@ public class FeatureToggle {
     }
 
     /**
-     * 业务是否对接cmdb业务集。临时实现，待核心功能完成之后使用第三方框架完成特性开关，支持运行时更新开关
+     * 业务是否对接cmdb业务集
      *
      * @param appId Job业务ID
      */
     public static boolean isCmdbBizSetEnabledForApp(Long appId) {
         FeatureToggleConfig featureToggleConfig = get();
         FeatureToggleConfig.ToggleConfig cmdbBizSetConfig = featureToggleConfig.getCmdbBizSet();
-        return cmdbBizSetConfig.isEnabled()
-            && (!cmdbBizSetConfig.isGray() // 未开启灰度，全量启用
-            || (CollectionUtils.isEmpty(cmdbBizSetConfig.getIncludeApps())
-            || cmdbBizSetConfig.getIncludeApps().contains(appId)) // 如果使用includeApps参数，需要判断是否包含该业务
-            && (CollectionUtils.isEmpty(cmdbBizSetConfig.getExcludeApps())
-            || !cmdbBizSetConfig.getExcludeApps().contains(appId))); // 如果使用excludeApps参数，需要判断是否排除该业务
+        return cmdbBizSetConfig.isOpen(String.valueOf(appId));
     }
 
+
     /**
-     * 是否对接cmdb业务集。临时实现，待核心功能完成之后使用第三方框架完成特性开关，支持运行时更新开关
+     * 是否对接cmdb业务集
      */
     public static boolean isCmdbBizSetEnabled() {
         FeatureToggleConfig featureToggleConfig = get();
         FeatureToggleConfig.ToggleConfig cmdbBizSetConfig = featureToggleConfig.getCmdbBizSet();
-        return cmdbBizSetConfig.isEnabled();
+        return cmdbBizSetConfig.isOpen();
     }
 
     /**
@@ -76,6 +71,6 @@ public class FeatureToggle {
     public static boolean isBkBizIdEnabled() {
         FeatureToggleConfig featureToggleConfig = get();
         FeatureToggleConfig.ToggleConfig toggleConfig = featureToggleConfig.getEsbApiParamBkBizId();
-        return toggleConfig.isEnabled();
+        return toggleConfig.isOpen();
     }
 }

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/feature/FeatureToggle.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/feature/FeatureToggle.java
@@ -26,6 +26,7 @@ package com.tencent.bk.job.common.util.feature;
 
 import com.tencent.bk.job.common.config.FeatureToggleConfig;
 import com.tencent.bk.job.common.util.ApplicationContextRegister;
+import org.apache.commons.collections4.CollectionUtils;
 
 /**
  * 特性开关
@@ -53,7 +54,11 @@ public class FeatureToggle {
         FeatureToggleConfig featureToggleConfig = get();
         FeatureToggleConfig.ToggleConfig cmdbBizSetConfig = featureToggleConfig.getCmdbBizSet();
         return cmdbBizSetConfig.isEnabled()
-            && (!cmdbBizSetConfig.isGray() || cmdbBizSetConfig.getGrayApps().contains(appId));
+            && (!cmdbBizSetConfig.isGray() // 未开启灰度，全量启用
+            || (CollectionUtils.isEmpty(cmdbBizSetConfig.getIncludeApps())
+            || cmdbBizSetConfig.getIncludeApps().contains(appId)) // 如果使用includeApps参数，需要判断是否包含该业务
+            && (CollectionUtils.isEmpty(cmdbBizSetConfig.getExcludeApps())
+            || !cmdbBizSetConfig.getExcludeApps().contains(appId))); // 如果使用excludeApps参数，需要判断是否排除该业务
     }
 
     /**

--- a/src/backend/job-analysis/boot-job-analysis/src/main/resources/application.yml
+++ b/src/backend/job-analysis/boot-job-analysis/src/main/resources/application.yml
@@ -16,7 +16,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks
+        include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,refresh
       base-path: /actuator
     enabled-by-default: false
   endpoint:
@@ -42,6 +42,8 @@ management:
     prometheus:
       enabled: true
     scheduledtasks:
+      enabled: true
+    refresh:
       enabled: true
 server:
   port: 19807

--- a/src/backend/job-backup/boot-job-backup/src/main/resources/application.yml
+++ b/src/backend/job-backup/boot-job-backup/src/main/resources/application.yml
@@ -15,7 +15,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info
+        include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info,refresh
       base-path: /actuator
     enabled-by-default: false
   endpoint:
@@ -43,6 +43,8 @@ management:
     scheduledtasks:
       enabled: true
     info:
+      enabled: true
+    refresh:
       enabled: true
 server:
   port: 19808

--- a/src/backend/job-crontab/boot-job-crontab/src/main/resources/application.yml
+++ b/src/backend/job-crontab/boot-job-crontab/src/main/resources/application.yml
@@ -16,7 +16,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info
+        include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info,refresh
       base-path: /actuator
     enabled-by-default: false
   endpoint:
@@ -44,6 +44,8 @@ management:
     scheduledtasks:
       enabled: true
     info:
+      enabled: true
+    refresh:
       enabled: true
 server:
   port: 19805

--- a/src/backend/job-execute/boot-job-execute/src/main/resources/application.yml
+++ b/src/backend/job-execute/boot-job-execute/src/main/resources/application.yml
@@ -16,7 +16,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info
+        include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info,refresh
       base-path: /actuator
     enabled-by-default: false
   endpoint:

--- a/src/backend/job-execute/boot-job-execute/src/main/resources/application.yml
+++ b/src/backend/job-execute/boot-job-execute/src/main/resources/application.yml
@@ -45,6 +45,8 @@ management:
       enabled: true
     info:
       enabled: true
+    refresh:
+      enabled: true
 
 server:
   port: 19804

--- a/src/backend/job-file-gateway/boot-job-file-gateway/src/main/resources/application.yml
+++ b/src/backend/job-file-gateway/boot-job-file-gateway/src/main/resources/application.yml
@@ -10,7 +10,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: shutdown,health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info
+        include: shutdown,health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info,refresh
       base-path: /actuator
     enabled-by-default: false
   endpoint:
@@ -37,6 +37,8 @@ management:
     scheduledtasks:
       enabled: true
     info:
+      enabled: true
+    refresh:
       enabled: true
   metrics:
     tags:

--- a/src/backend/job-gateway/src/main/resources/application.yml
+++ b/src/backend/job-gateway/src/main/resources/application.yml
@@ -231,7 +231,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info
+        include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info,refresh
       base-path: /actuator
     enabled-by-default: false
   endpoint:
@@ -259,6 +259,8 @@ management:
     scheduledtasks:
       enabled: true
     info:
+      enabled: true
+    refresh:
       enabled: true
 
 job:

--- a/src/backend/job-logsvr/boot-job-logsvr/src/main/resources/application.yml
+++ b/src/backend/job-logsvr/boot-job-logsvr/src/main/resources/application.yml
@@ -29,7 +29,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info
+        include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info,refresh
       base-path: /actuator
     enabled-by-default: false
   endpoint:
@@ -57,6 +57,8 @@ management:
     scheduledtasks:
       enabled: true
     info:
+      enabled: true
+    refresh:
       enabled: true
 server:
   port: 19806

--- a/src/backend/job-manage/boot-job-manage/src/main/resources/application.yml
+++ b/src/backend/job-manage/boot-job-manage/src/main/resources/application.yml
@@ -16,7 +16,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info
+        include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info,refresh
       base-path: /actuator
     enabled-by-default: false
   endpoint:

--- a/src/backend/job-manage/boot-job-manage/src/main/resources/application.yml
+++ b/src/backend/job-manage/boot-job-manage/src/main/resources/application.yml
@@ -45,6 +45,8 @@ management:
       enabled: true
     info:
       enabled: true
+    refresh:
+      enabled: true
 server:
   port: 19803
   shutdown: graceful

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/AbstractCmdbResourceEventWatcher.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/AbstractCmdbResourceEventWatcher.java
@@ -57,11 +57,6 @@ public abstract class AbstractCmdbResourceEventWatcher<E> extends Thread {
         try {
             while (true) {
                 try {
-                    if (!isWatchingEnabled()) {
-                        ThreadUtils.sleep(60_000);
-                        continue;
-                    }
-
                     boolean lockGotten = tryGetTaskLockPeriodically();
                     if (!lockGotten) {
                         // 30s之后重试
@@ -127,7 +122,7 @@ public abstract class AbstractCmdbResourceEventWatcher<E> extends Thread {
         log.info("Start watch {} resource at {},{}", watcherResourceName, TimeUtil.getCurrentTimeStr("HH:mm:ss"),
             System.currentTimeMillis());
         String cursor = null;
-        while (true) {
+        while (isWatchingEnabled()) {
             Span span = null;
             try {
                 ResourceWatchResult<E> watchResult;

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/AbstractCmdbResourceEventWatcher.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/AbstractCmdbResourceEventWatcher.java
@@ -139,8 +139,8 @@ public abstract class AbstractCmdbResourceEventWatcher<E> extends Thread {
                     }
                     log.info("WatchResult[{}]: {}", this.watcherResourceName, JsonUtils.toJson(watchResult));
                     cursor = handleWatchResult(watchResult, cursor);
-                    // 10s/watch一次
-                    ThreadUtils.sleep(10_000);
+                    // 1s/watch一次
+                    ThreadUtils.sleep(1_000);
                 } catch (Throwable t) {
                     if (span != null) {
                         span.error(t);

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/AbstractCmdbResourceEventWatcher.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/AbstractCmdbResourceEventWatcher.java
@@ -122,6 +122,7 @@ public abstract class AbstractCmdbResourceEventWatcher<E> extends Thread {
         log.info("Start watch {} resource at {},{}", watcherResourceName, TimeUtil.getCurrentTimeStr("HH:mm:ss"),
             System.currentTimeMillis());
         String cursor = null;
+
         while (isWatchingEnabled()) {
             Span span = null;
             try {
@@ -147,6 +148,8 @@ public abstract class AbstractCmdbResourceEventWatcher<E> extends Thread {
                 log.error("EventWatch thread fail", t);
                 cursor = null;
             }
+            // 如果事件开关为disabled，间隔30s重新判断是否开启
+            ThreadUtils.sleep(30_000L);
         }
     }
 

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/AbstractCmdbResourceEventWatcher.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/AbstractCmdbResourceEventWatcher.java
@@ -146,7 +146,8 @@ public abstract class AbstractCmdbResourceEventWatcher<E> extends Thread {
                         span.error(t);
                     }
                     log.error("EventWatch thread fail", t);
-                    cursor = null;
+                    // 如果处理事件过程中碰到异常，等待30s重试
+                    ThreadUtils.sleep(30_000);
                 }
             }
             // 如果事件开关为disabled，间隔30s重新判断是否开启

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/AbstractCmdbResourceEventWatcher.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/AbstractCmdbResourceEventWatcher.java
@@ -122,35 +122,37 @@ public abstract class AbstractCmdbResourceEventWatcher<E> extends Thread {
         log.info("Start watch {} resource at {},{}", watcherResourceName, TimeUtil.getCurrentTimeStr("HH:mm:ss"),
             System.currentTimeMillis());
         String cursor = null;
-
-        while (isWatchingEnabled()) {
-            Span span = null;
-            try {
-                ResourceWatchResult<E> watchResult;
-                span = this.tracing.tracer().newTrace();
-                if (cursor == null) {
-                    // 从10分钟前开始watch
-                    long startTime = System.currentTimeMillis() / 1000 - 10 * 60;
-                    log.info("Start watch {} from startTime:{}", this.watcherResourceName,
-                        TimeUtil.formatTime(startTime * 1000));
-                    watchResult = fetchEventsByStartTime(startTime);
-                } else {
-                    watchResult = fetchEventsByCursor(cursor);
+        while (true) {
+            while (isWatchingEnabled()) {
+                Span span = null;
+                try {
+                    ResourceWatchResult<E> watchResult;
+                    span = this.tracing.tracer().newTrace();
+                    if (cursor == null) {
+                        // 从10分钟前开始watch
+                        long startTime = System.currentTimeMillis() / 1000 - 10 * 60;
+                        log.info("Start watch {} from startTime:{}", this.watcherResourceName,
+                            TimeUtil.formatTime(startTime * 1000));
+                        watchResult = fetchEventsByStartTime(startTime);
+                    } else {
+                        watchResult = fetchEventsByCursor(cursor);
+                    }
+                    log.info("WatchResult[{}]: {}", this.watcherResourceName, JsonUtils.toJson(watchResult));
+                    cursor = handleWatchResult(watchResult, cursor);
+                    // 10s/watch一次
+                    ThreadUtils.sleep(10_000);
+                } catch (Throwable t) {
+                    if (span != null) {
+                        span.error(t);
+                    }
+                    log.error("EventWatch thread fail", t);
+                    cursor = null;
                 }
-                log.info("WatchResult[{}]: {}", this.watcherResourceName, JsonUtils.toJson(watchResult));
-                cursor = handleWatchResult(watchResult, cursor);
-                // 10s/watch一次
-                ThreadUtils.sleep(10_000);
-            } catch (Throwable t) {
-                if (span != null) {
-                    span.error(t);
-                }
-                log.error("EventWatch thread fail", t);
-                cursor = null;
             }
             // 如果事件开关为disabled，间隔30s重新判断是否开启
             ThreadUtils.sleep(30_000L);
         }
+
     }
 
     private String handleWatchResult(ResourceWatchResult<E> watchResult,

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/BizSetEventWatcher.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/BizSetEventWatcher.java
@@ -55,6 +55,11 @@ public class BizSetEventWatcher extends AbstractCmdbResourceEventWatcher<BizSetE
         String eventType = event.getEventType();
         ApplicationDTO cachedApp =
             applicationService.getAppByScopeIncludingDeleted(latestApp.getScope());
+        if (cachedApp != null && !FeatureToggle.isCmdbBizSetEnabledForApp(cachedApp.getId())) {
+            log.info("Ignore cmdb biz set event, app[{}] cmdb biz set feature toggle is disabled", cachedApp.getId());
+            return;
+        }
+
         switch (eventType) {
             case ResourceWatchReq.EVENT_TYPE_CREATE:
             case ResourceWatchReq.EVENT_TYPE_UPDATE:

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/BizSetEventWatcher.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/BizSetEventWatcher.java
@@ -113,7 +113,7 @@ public class BizSetEventWatcher extends AbstractCmdbResourceEventWatcher<BizSetE
         boolean isCmdbBizSetEnabled = FeatureToggle.isCmdbBizSetEnabled();
         boolean isWatchingEnabled = isBizSetMigratedToCMDB && isCmdbBizSetEnabled;
         if (!isWatchingEnabled) {
-            log.warn("Watching biz set disabled, isBizSetMigratedToCMDB: {}, isCmdbBizSetEnabled: {}",
+            log.info("Watching biz set disabled, isBizSetMigratedToCMDB: {}, isCmdbBizSetEnabled: {}",
                 isBizSetMigratedToCMDB, isCmdbBizSetEnabled);
         }
         return isWatchingEnabled;

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/BizSetEventWatcher.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/BizSetEventWatcher.java
@@ -7,6 +7,7 @@ import com.tencent.bk.job.common.cc.model.result.ResourceEvent;
 import com.tencent.bk.job.common.cc.model.result.ResourceWatchResult;
 import com.tencent.bk.job.common.cc.sdk.BizSetCmdbClient;
 import com.tencent.bk.job.common.model.dto.ApplicationDTO;
+import com.tencent.bk.job.common.util.feature.FeatureToggle;
 import com.tencent.bk.job.manage.service.ApplicationService;
 import com.tencent.bk.job.manage.service.impl.BizSetService;
 import lombok.extern.slf4j.Slf4j;
@@ -103,13 +104,13 @@ public class BizSetEventWatcher extends AbstractCmdbResourceEventWatcher<BizSetE
 
     @Override
     protected boolean isWatchingEnabled() {
-        boolean isEnabled = bizSetService.isBizSetMigratedToCMDB();
-        if (!isEnabled) {
-            log.warn("Job BizSets have not been migrated to CMDB, " +
-                "do not watch bizSet event from CMDB, " +
-                "please use upgrader in package to migrate as soon as possible"
-            );
+        boolean isBizSetMigratedToCMDB = bizSetService.isBizSetMigratedToCMDB();
+        boolean isCmdbBizSetEnabled = FeatureToggle.isCmdbBizSetEnabled();
+        boolean isWatchingEnabled = isBizSetMigratedToCMDB && isCmdbBizSetEnabled;
+        if (!isWatchingEnabled) {
+            log.warn("Watching biz set disabled, isBizSetMigratedToCMDB: {}, isCmdbBizSetEnabled: {}",
+                isBizSetMigratedToCMDB, isCmdbBizSetEnabled);
         }
-        return isEnabled;
+        return isWatchingEnabled;
     }
 }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/BizSetRelationEventWatcher.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/BizSetRelationEventWatcher.java
@@ -55,6 +55,7 @@ public class BizSetRelationEventWatcher extends AbstractCmdbResourceEventWatcher
     @Override
     protected void handleEvent(ResourceEvent<BizSetRelationEventDetail> event) {
         log.info("Handle BizSetRelationEvent: {}", event);
+
         String eventType = event.getEventType();
         switch (eventType) {
             case ResourceWatchReq.EVENT_TYPE_UPDATE:
@@ -66,6 +67,11 @@ public class BizSetRelationEventWatcher extends AbstractCmdbResourceEventWatcher
                             new ResourceScope(ResourceScopeTypeEnum.BIZ_SET.getValue(), String.valueOf(bizSetId))
                         );
                     if (cacheApplication == null || cacheApplication.isDeleted()) {
+                        return;
+                    }
+                    if (!FeatureToggle.isCmdbBizSetEnabledForApp(cacheApplication.getId())) {
+                        log.info("Ignore cmdb biz set relation event, app[{}] cmdb biz set feature toggle is disabled",
+                            cacheApplication.getId());
                         return;
                     }
                     cacheApplication.setSubBizIds(latestSubBizIds);

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/BizSetRelationEventWatcher.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/BizSetRelationEventWatcher.java
@@ -96,7 +96,7 @@ public class BizSetRelationEventWatcher extends AbstractCmdbResourceEventWatcher
         boolean isCmdbBizSetEnabled = FeatureToggle.isCmdbBizSetEnabled();
         boolean isWatchingEnabled = isBizSetMigratedToCMDB && isCmdbBizSetEnabled;
         if (!isWatchingEnabled) {
-            log.warn("Watching biz set disabled, isBizSetMigratedToCMDB: {}, isCmdbBizSetEnabled: {}",
+            log.info("Watching biz set disabled, isBizSetMigratedToCMDB: {}, isCmdbBizSetEnabled: {}",
                 isBizSetMigratedToCMDB, isCmdbBizSetEnabled);
         }
         return isWatchingEnabled;

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/BizSetRelationEventWatcher.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/BizSetRelationEventWatcher.java
@@ -10,6 +10,7 @@ import com.tencent.bk.job.common.constant.ResourceScopeTypeEnum;
 import com.tencent.bk.job.common.model.dto.ApplicationAttrsDO;
 import com.tencent.bk.job.common.model.dto.ApplicationDTO;
 import com.tencent.bk.job.common.model.dto.ResourceScope;
+import com.tencent.bk.job.common.util.feature.FeatureToggle;
 import com.tencent.bk.job.manage.service.ApplicationService;
 import com.tencent.bk.job.manage.service.impl.BizSetService;
 import lombok.extern.slf4j.Slf4j;
@@ -85,13 +86,13 @@ public class BizSetRelationEventWatcher extends AbstractCmdbResourceEventWatcher
 
     @Override
     protected boolean isWatchingEnabled() {
-        boolean isEnabled = bizSetService.isBizSetMigratedToCMDB();
-        if (!isEnabled) {
-            log.warn("Job BizSets have not been migrated to CMDB, " +
-                "do not watch bizSet event from CMDB, " +
-                "please use upgrader in package to migrate as soon as possible"
-            );
+        boolean isBizSetMigratedToCMDB = bizSetService.isBizSetMigratedToCMDB();
+        boolean isCmdbBizSetEnabled = FeatureToggle.isCmdbBizSetEnabled();
+        boolean isWatchingEnabled = isBizSetMigratedToCMDB && isCmdbBizSetEnabled;
+        if (!isWatchingEnabled) {
+            log.warn("Watching biz set disabled, isBizSetMigratedToCMDB: {}, isCmdbBizSetEnabled: {}",
+                isBizSetMigratedToCMDB, isCmdbBizSetEnabled);
         }
-        return isEnabled;
+        return isWatchingEnabled;
     }
 }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/BizSetSyncService.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/BizSetSyncService.java
@@ -100,8 +100,8 @@ public class BizSetSyncService extends BasicAppSyncService {
         List<ApplicationDTO> localBizSetApps = applicationDAO.listAllBizSetAppsWithDeleted();
         // 本地业务bizId
         Set<Long> localBizSetIds =
-            localBizSetApps.stream().
-                map(localBizSetApp -> Long.valueOf(localBizSetApp.getScope().getId()))
+            localBizSetApps.stream()
+                .map(localBizSetApp -> Long.valueOf(localBizSetApp.getScope().getId()))
                 .collect(Collectors.toSet());
         log.info("Local cached bizSetIds: {}", localBizSetIds);
 
@@ -200,5 +200,9 @@ public class BizSetSyncService extends BasicAppSyncService {
         appInfoDTO.setScope(
             new ResourceScope(ResourceScopeTypeEnum.BIZ_SET, bizSetInfo.getId().toString()));
         return appInfoDTO;
+    }
+
+    private void filterGrayBizSet() {
+
     }
 }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/SyncServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/SyncServiceImpl.java
@@ -333,8 +333,10 @@ public class SyncServiceImpl implements SyncService {
                     // 从CMDB同步业务集信息
                     if (FeatureToggle.isCmdbBizSetEnabled()) {
                         bizSetSyncService.syncBizSetFromCMDB();
+                    } else {
+                        log.info("Cmdb biz set is disabled, skip sync apps!");
                     }
-                    log.info(Thread.currentThread().getName() + ":Finished:sync app from cc");
+                    log.info(Thread.currentThread().getName() + ":Finished:sync app from cmdb");
                     // 将最后同步时间写入Redis
                     redisTemplate.opsForValue().set(REDIS_KEY_LAST_FINISH_TIME_SYNC_APP,
                         "" + System.currentTimeMillis());

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/SyncServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/SyncServiceImpl.java
@@ -238,14 +238,9 @@ public class SyncServiceImpl implements SyncService {
      * 监听业务集相关的事件
      */
     private void watchBizSetEvent() {
-        if (FeatureToggle.isCmdbBizSetEnabled()) {
-            log.info("Cmdb biz set is enabled, watch biz_set and biz_set_relation resource event");
-            // 开一个常驻线程监听业务集变动事件
-            bizSetEventWatcher.start();
-            bizSetRelationEventWatcher.start();
-        } else {
-            log.info("Cmdb biz set is disabled, ignore related event");
-        }
+        // 开一个常驻线程监听业务集变动事件
+        bizSetEventWatcher.start();
+        bizSetRelationEventWatcher.start();
     }
 
     public boolean addExtraSyncBizHostsTask(Long bizId) {

--- a/support-files/kubernetes/charts/bk-job/Chart.yaml
+++ b/support-files/kubernetes/charts/bk-job/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: "bk-job"
 description: The BK-JOB is a ops script management and execution system with the capability of dealing with multiple tasks simultaneously.
 type: application
-version: 0.2.2-rc.4
-appVersion: "3.5.0-rc.6"
+version: 0.2.2-rc.5
+appVersion: "3.5.0-rc.7"
 
 dependencies:
 - name: common

--- a/support-files/kubernetes/charts/bk-job/templates/job-analysis/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-analysis/configmap.yaml
@@ -13,9 +13,6 @@ metadata:
 data:
   application.yaml: |-
     spring:
-      cloud:
-        refresh:
-          extra-refreshable: javax.sql.DataSource
       datasource:
         job-analysis:
           driver-class-name: com.mysql.cj.jdbc.Driver

--- a/support-files/kubernetes/charts/bk-job/templates/job-backup/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-backup/configmap.yaml
@@ -13,9 +13,6 @@ metadata:
 data:
   application.yaml: |-
     spring:
-      cloud:
-        refresh:
-          extra-refreshable: javax.sql.DataSource
       datasource:
         job-backup:
           driver-class-name: com.mysql.cj.jdbc.Driver

--- a/support-files/kubernetes/charts/bk-job/templates/job-crontab/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-crontab/configmap.yaml
@@ -13,9 +13,6 @@ metadata:
 data:
   application.yaml: |-
     spring:
-      cloud:
-        refresh:
-          extra-refreshable: javax.sql.DataSource
       datasource:
         job-crontab:
           driver-class-name: com.mysql.cj.jdbc.Driver

--- a/support-files/kubernetes/charts/bk-job/templates/job-execute/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-execute/configmap.yaml
@@ -130,8 +130,6 @@ data:
               taskStatisticsOutput:
                 consumer:
                   maxConcurrency: 10
-        refresh:
-          extra-refreshable: javax.sql.DataSource
       datasource:
         job-execute:
           driver-class-name: com.mysql.cj.jdbc.Driver

--- a/support-files/kubernetes/charts/bk-job/templates/job-file-gateway/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-file-gateway/configmap.yaml
@@ -13,9 +13,6 @@ metadata:
 data:
   application.yaml: |-
     spring:
-      cloud:
-        refresh:
-          extra-refreshable: javax.sql.DataSource
       datasource:
         job-file-gateway:
           driver-class-name: com.mysql.cj.jdbc.Driver

--- a/support-files/kubernetes/charts/bk-job/templates/job-manage/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-manage/configmap.yaml
@@ -13,9 +13,6 @@ metadata:
 data:
   application.yaml: |-
     spring:
-      cloud:
-        refresh:
-          extra-refreshable: javax.sql.DataSource
       datasource:
         job-manage:
           driver-class-name: com.mysql.cj.jdbc.Driver

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -645,7 +645,7 @@ gatewayConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-gateway
-    tag: 3.5.0-rc.6
+    tag: 3.5.0-rc.7
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -733,7 +733,7 @@ manageConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-manage
-    tag: 3.5.0-rc.6
+    tag: 3.5.0-rc.7
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -791,7 +791,7 @@ executeConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-execute
-    tag: 3.5.0-rc.6
+    tag: 3.5.0-rc.7
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -842,7 +842,7 @@ crontabConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-crontab
-    tag: 3.5.0-rc.6
+    tag: 3.5.0-rc.7
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -902,7 +902,7 @@ logsvrConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-logsvr
-    tag: 3.5.0-rc.6
+    tag: 3.5.0-rc.7
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -957,7 +957,7 @@ backupConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-backup
-    tag: 3.5.0-rc.6
+    tag: 3.5.0-rc.7
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -1007,7 +1007,7 @@ analysisConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-analysis
-    tag: 3.5.0-rc.6
+    tag: 3.5.0-rc.7
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -1057,7 +1057,7 @@ fileGatewayConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-file-gateway
-    tag: 3.5.0-rc.6
+    tag: 3.5.0-rc.7
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -1107,7 +1107,7 @@ fileWorkerConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-file-worker
-    tag: 3.5.0-rc.6
+    tag: 3.5.0-rc.7
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -1180,7 +1180,7 @@ frontendConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-frontend
-    tag: 3.5.0-rc.6
+    tag: 3.5.0-rc.7
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -1241,7 +1241,7 @@ migration:
     # 镜像拉取仓库组织与镜像名称
     repository: "blueking/job-migration"
     # 镜像标签
-    tag: 3.5.0-rc.6
+    tag: 3.5.0-rc.7
     # 镜像拉取策略
     pullPolicy: IfNotPresent
 

--- a/support-files/templates/#etc#job#job-analysis#job-analysis.yml
+++ b/support-files/templates/#etc#job#job-analysis#job-analysis.yml
@@ -1,9 +1,6 @@
 spring:
   application:
     name: job-analysis
-  cloud:
-    refresh:
-      extra-refreshable: javax.sql.DataSource
   datasource:
     job-analysis:
       driver-class-name: com.mysql.cj.jdbc.Driver

--- a/support-files/templates/#etc#job#job-backup#job-backup.yml
+++ b/support-files/templates/#etc#job#job-backup#job-backup.yml
@@ -1,9 +1,6 @@
 spring:
   application:
     name: job-backup
-  cloud:
-    refresh:
-      extra-refreshable: javax.sql.DataSource
   datasource:
     job-backup:
       driver-class-name: com.mysql.cj.jdbc.Driver

--- a/support-files/templates/#etc#job#job-crontab#job-crontab.yml
+++ b/support-files/templates/#etc#job#job-crontab#job-crontab.yml
@@ -1,9 +1,6 @@
 spring:
   application:
     name: job-crontab
-  cloud:
-    refresh:
-      extra-refreshable: javax.sql.DataSource
   datasource:
     job-crontab:
       driver-class-name: com.mysql.cj.jdbc.Driver

--- a/support-files/templates/#etc#job#job-execute#job-execute.yml
+++ b/support-files/templates/#etc#job#job-execute#job-execute.yml
@@ -118,8 +118,6 @@ spring:
           taskStatisticsOutput:
             consumer:
               maxConcurrency: 10
-    refresh:
-      extra-refreshable: javax.sql.DataSource
   datasource:
     job-execute:
       driver-class-name: com.mysql.cj.jdbc.Driver

--- a/support-files/templates/#etc#job#job-file-gateway#job-file-gateway.yml
+++ b/support-files/templates/#etc#job#job-file-gateway#job-file-gateway.yml
@@ -1,9 +1,6 @@
 spring:
   application:
     name: job-file-gateway
-  cloud:
-    refresh:
-      extra-refreshable: javax.sql.DataSource
   datasource:
     job-file-gateway:
       driver-class-name: com.mysql.cj.jdbc.Driver

--- a/support-files/templates/#etc#job#job-manage#job-manage.yml
+++ b/support-files/templates/#etc#job#job-manage#job-manage.yml
@@ -1,9 +1,6 @@
 spring:
   application:
     name: job-manage
-  cloud:
-    refresh:
-      extra-refreshable: javax.sql.DataSource
   datasource:
     job-manage:
       driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
1. cmdb业务集的同步与事件支持特性开关控制，并支持按照appId灰度(includeApps/excludeApps两种模式）
2. 开启actuator refresh 扩展点，用于刷新配置，动态获取最新的开关配置
3. 删除spring.cloud.refresh.extra-refreshable(会导致DataSource在配置刷新的时候restart，原先引入这个配置没有必要，早期bug)
4. 自动忽略没有对接cmdb业务集的事件与同步数据