### PR TITLE
bugfix: 监听主机事件顺序导致host表的业务ID字段为-1，影响作业执行 #959

### DIFF
--- a/src/backend/commons/cmdb-sdk-model/src/main/java/com/tencent/bk/job/common/cc/model/BaseRuleDTO.java
+++ b/src/backend/commons/cmdb-sdk-model/src/main/java/com/tencent/bk/job/common/cc/model/BaseRuleDTO.java
@@ -24,17 +24,27 @@
 
 package com.tencent.bk.job.common.cc.model;
 
-import lombok.Data;
-
-import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
- * @since 19/12/2019 21:25
+ * cmdb 查询规则
  */
-@Data
-public class ConditionDTO {
-
-    private String condition;
-
-    private List<BaseConditionDTO> rules;
+@Getter
+@Setter
+@ToString
+public class BaseRuleDTO implements IRule {
+    /**
+     * 字段名
+     */
+    private String field;
+    /**
+     * 操作符,可选值 equal,not_equal,in,not_in,less,less_or_equal,greater,greater_or_equal,between,not_between
+     */
+    private String operator;
+    /**
+     * 操作值，不同的operator对应不同的value格式
+     */
+    private Object value;
 }

--- a/src/backend/commons/cmdb-sdk-model/src/main/java/com/tencent/bk/job/common/cc/model/ComposeRuleDTO.java
+++ b/src/backend/commons/cmdb-sdk-model/src/main/java/com/tencent/bk/job/common/cc/model/ComposeRuleDTO.java
@@ -22,25 +22,37 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.common.cc.model.result;
+package com.tencent.bk.job.common.cc.model;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
 
-public class FindHostBizRelationsResult {
+/**
+ * cmdb 组合查询规则
+ */
+@Getter
+@Setter
+@ToString
+public class ComposeRuleDTO implements IRule {
+    /**
+     * 组合查询条件
+     */
+    private String condition;
+    /**
+     * 过滤规则
+     */
+    private List<IRule> rules = new ArrayList<>();
 
-    @JsonProperty("bk_biz_id")
-    private Long bizId;
-
-    @JsonProperty("bk_host_id")
-    private Long hostId;
-
-    @JsonProperty("bk_module_id")
-    private Long moduleId;
-
-    @JsonProperty("bk_set_id")
-    private Long setId;
-
-    @JsonProperty("bk_supplier_account")
-    private String supplierAccount;
+    /**
+     * 新增过滤规则
+     *
+     * @param rule 过滤规则
+     */
+    public void addRule(IRule rule) {
+        this.rules.add(rule);
+    }
 }

--- a/src/backend/commons/cmdb-sdk-model/src/main/java/com/tencent/bk/job/common/cc/model/IRule.java
+++ b/src/backend/commons/cmdb-sdk-model/src/main/java/com/tencent/bk/job/common/cc/model/IRule.java
@@ -1,0 +1,7 @@
+package com.tencent.bk.job.common.cc.model;
+
+/**
+ * CMDB 资源过滤规则
+ */
+public interface IRule {
+}

--- a/src/backend/commons/cmdb-sdk-model/src/main/java/com/tencent/bk/job/common/cc/model/PropertyFilterDTO.java
+++ b/src/backend/commons/cmdb-sdk-model/src/main/java/com/tencent/bk/job/common/cc/model/PropertyFilterDTO.java
@@ -24,21 +24,31 @@
 
 package com.tencent.bk.job.common.cc.model;
 
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * @since 19/12/2019 21:26
+ * cmdb 过滤查询模型
  */
-@Getter
-@Setter
-@ToString
-public class BaseConditionDTO {
+@Data
+public class PropertyFilterDTO {
+    /**
+     * 组合查询条件
+     */
+    private String condition;
+    /**
+     * 过滤规则
+     */
+    private List<IRule> rules = new ArrayList<>();
 
-    private String field;
-
-    private String operator;
-
-    private Object value;
+    /**
+     * 新增过滤规则
+     *
+     * @param rule 过滤规则
+     */
+    public void addRule(IRule rule) {
+        this.rules.add(rule);
+    }
 }

--- a/src/backend/commons/cmdb-sdk-model/src/main/java/com/tencent/bk/job/common/cc/model/req/ListBizHostReq.java
+++ b/src/backend/commons/cmdb-sdk-model/src/main/java/com/tencent/bk/job/common/cc/model/req/ListBizHostReq.java
@@ -25,8 +25,8 @@
 package com.tencent.bk.job.common.cc.model.req;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.tencent.bk.job.common.cc.model.BaseConditionDTO;
-import com.tencent.bk.job.common.cc.model.ConditionDTO;
+import com.tencent.bk.job.common.cc.model.BaseRuleDTO;
+import com.tencent.bk.job.common.cc.model.PropertyFilterDTO;
 import com.tencent.bk.job.common.esb.model.EsbReq;
 import com.tencent.bk.job.common.model.dto.PageDTO;
 import lombok.Getter;
@@ -48,13 +48,13 @@ public class ListBizHostReq extends EsbReq {
     private List<Long> setIds;
 
     @JsonProperty("set_cond")
-    private List<BaseConditionDTO> setCondition;
+    private List<BaseRuleDTO> setCondition;
 
     @JsonProperty("module_ids")
     private List<Long> moduleIds;
 
     @JsonProperty("host_property_filter")
-    private ConditionDTO condition;
+    private PropertyFilterDTO condition;
 
     @JsonProperty("fields")
     private List<String> fields = Arrays.asList("bk_host_id", "bk_host_innerip", "bk_host_name", "bk_os_name",

--- a/src/backend/commons/cmdb-sdk-model/src/main/java/com/tencent/bk/job/common/cc/model/result/HostBizRelationDTO.java
+++ b/src/backend/commons/cmdb-sdk-model/src/main/java/com/tencent/bk/job/common/cc/model/result/HostBizRelationDTO.java
@@ -22,27 +22,30 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.common.cc.model.req;
+package com.tencent.bk.job.common.cc.model.result;
+
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.tencent.bk.job.common.cc.model.PropertyFilterDTO;
-import com.tencent.bk.job.common.esb.model.EsbReq;
-import com.tencent.bk.job.common.model.dto.PageDTO;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.Data;
 
-import java.util.Arrays;
-import java.util.List;
+/**
+ * 主机业务关系信息
+ */
+@Data
+public class HostBizRelationDTO {
 
-@Getter
-@Setter
-public class ListHostsWithoutBizReq extends EsbReq {
-    @JsonProperty("host_property_filter")
-    private PropertyFilterDTO condition;
+    @JsonProperty("bk_biz_id")
+    private Long bizId;
 
-    @JsonProperty("fields")
-    private List<String> fields = Arrays.asList("bk_host_id", "bk_host_innerip", "bk_host_name", "bk_os_name",
-        "bk_cloud_id");
+    @JsonProperty("bk_host_id")
+    private Long hostId;
 
-    private PageDTO page;
+    @JsonProperty("bk_module_id")
+    private Long moduleId;
+
+    @JsonProperty("bk_set_id")
+    private Long setId;
+
+    @JsonProperty("bk_supplier_account")
+    private String supplierAccount;
 }

--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BizCmdbClient.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BizCmdbClient.java
@@ -1066,7 +1066,7 @@ public class BizCmdbClient extends AbstractEsbSdkClient implements IBizCmdbClien
     }
 
     private List<ApplicationHostDTO> listHostsWithoutBiz(ListHostsWithoutBizReq req) {
-        int limit = 1;
+        int limit = 500;
         int start = 0;
         PageDTO page = new PageDTO(start, limit, "");
         req.setPage(page);

--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BizCmdbClient.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BizCmdbClient.java
@@ -30,7 +30,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.tencent.bk.job.common.cc.config.CmdbConfig;
 import com.tencent.bk.job.common.cc.model.AppRoleDTO;
-import com.tencent.bk.job.common.cc.model.BaseConditionDTO;
+import com.tencent.bk.job.common.cc.model.BaseRuleDTO;
 import com.tencent.bk.job.common.cc.model.BriefTopologyDTO;
 import com.tencent.bk.job.common.cc.model.BusinessInfoDTO;
 import com.tencent.bk.job.common.cc.model.CcCloudAreaInfoDTO;
@@ -41,8 +41,9 @@ import com.tencent.bk.job.common.cc.model.CcGroupHostPropDTO;
 import com.tencent.bk.job.common.cc.model.CcHostInfoDTO;
 import com.tencent.bk.job.common.cc.model.CcInstanceDTO;
 import com.tencent.bk.job.common.cc.model.CcObjAttributeDTO;
-import com.tencent.bk.job.common.cc.model.ConditionDTO;
+import com.tencent.bk.job.common.cc.model.ComposeRuleDTO;
 import com.tencent.bk.job.common.cc.model.InstanceTopologyDTO;
+import com.tencent.bk.job.common.cc.model.PropertyFilterDTO;
 import com.tencent.bk.job.common.cc.model.TopoNodePathDTO;
 import com.tencent.bk.job.common.cc.model.req.ExecuteDynamicGroupReq;
 import com.tencent.bk.job.common.cc.model.req.FindHostBizRelationsReq;
@@ -63,9 +64,9 @@ import com.tencent.bk.job.common.cc.model.req.input.GetHostByIpInput;
 import com.tencent.bk.job.common.cc.model.response.CcCountInfo;
 import com.tencent.bk.job.common.cc.model.result.BizEventDetail;
 import com.tencent.bk.job.common.cc.model.result.ExecuteDynamicGroupHostResult;
-import com.tencent.bk.job.common.cc.model.result.FindHostBizRelationsResult;
 import com.tencent.bk.job.common.cc.model.result.FindModuleHostRelationResult;
 import com.tencent.bk.job.common.cc.model.result.GetBizInternalModuleResult;
+import com.tencent.bk.job.common.cc.model.result.HostBizRelationDTO;
 import com.tencent.bk.job.common.cc.model.result.HostEventDetail;
 import com.tencent.bk.job.common.cc.model.result.HostRelationEventDetail;
 import com.tencent.bk.job.common.cc.model.result.ListBizHostResult;
@@ -959,13 +960,13 @@ public class BizCmdbClient extends AbstractEsbSdkClient implements IBizCmdbClien
     }
 
     @Override
-    public List<FindHostBizRelationsResult> findHostBizRelations(String uin, List<Long> hostIdList) {
+    public List<HostBizRelationDTO> findHostBizRelations(String uin, List<Long> hostIdList) {
         FindHostBizRelationsReq req = makeBaseReq(FindHostBizRelationsReq.class, defaultUin, defaultSupplierAccount);
         req.setHostIdList(hostIdList);
-        EsbResp<List<FindHostBizRelationsResult>> esbResp = requestCmdbApi(HttpPost.METHOD_NAME,
-            FIND_HOST_BIZ_RELATIONS, req, new TypeReference<EsbResp<List<FindHostBizRelationsResult>>>() {
+        EsbResp<List<HostBizRelationDTO>> esbResp = requestCmdbApi(HttpPost.METHOD_NAME,
+            FIND_HOST_BIZ_RELATIONS, req, new TypeReference<EsbResp<List<HostBizRelationDTO>>>() {
             });
-        List<FindHostBizRelationsResult> results = esbResp.getData();
+        List<HostBizRelationDTO> results = esbResp.getData();
         if (esbResp.getData() == null) {
             return Collections.emptyList();
         }
@@ -977,16 +978,14 @@ public class BizCmdbClient extends AbstractEsbSdkClient implements IBizCmdbClien
         List<ApplicationHostDTO> hostInfoList = new ArrayList<>();
         ListBizHostReq req = makeBaseReq(ListBizHostReq.class, defaultUin, defaultSupplierAccount);
         req.setBizId(input.getBizId());
-        ConditionDTO condition = new ConditionDTO();
+        PropertyFilterDTO condition = new PropertyFilterDTO();
         condition.setCondition("AND");
-        List<BaseConditionDTO> rules = new ArrayList<>();
         input.ipList.removeIf(StringUtils::isBlank);
-        BaseConditionDTO baseConditionDTO = new BaseConditionDTO();
-        baseConditionDTO.setField("bk_host_innerip");
-        baseConditionDTO.setOperator("in");
-        baseConditionDTO.setValue(input.ipList);
-        rules.add(baseConditionDTO);
-        condition.setRules(rules);
+        BaseRuleDTO baseRuleDTO = new BaseRuleDTO();
+        baseRuleDTO.setField("bk_host_innerip");
+        baseRuleDTO.setOperator("in");
+        baseRuleDTO.setValue(input.ipList);
+        condition.addRule(baseRuleDTO);
         req.setCondition(condition);
 
         int limit = 200;
@@ -1020,34 +1019,100 @@ public class BizCmdbClient extends AbstractEsbSdkClient implements IBizCmdbClien
     @Override
     public ApplicationHostDTO getHostByIp(Long cloudAreaId, String ip) {
         ListHostsWithoutBizReq req = makeBaseReq(ListHostsWithoutBizReq.class, defaultUin, defaultSupplierAccount);
-        ConditionDTO condition = new ConditionDTO();
+        PropertyFilterDTO condition = new PropertyFilterDTO();
         condition.setCondition("AND");
-        List<BaseConditionDTO> rules = new ArrayList<>();
-        BaseConditionDTO ipCondition = new BaseConditionDTO();
-        ipCondition.setField("bk_host_innerip");
-        ipCondition.setOperator("equal");
-        ipCondition.setValue(ip);
-        BaseConditionDTO cloudAreaIdCondition = new BaseConditionDTO();
-        cloudAreaIdCondition.setField("bk_cloud_id");
-        cloudAreaIdCondition.setOperator("equal");
-        cloudAreaIdCondition.setValue(cloudAreaId);
-        rules.add(ipCondition);
-        rules.add(cloudAreaIdCondition);
-        condition.setRules(rules);
+        BaseRuleDTO ipRule = new BaseRuleDTO();
+        ipRule.setField("bk_host_innerip");
+        ipRule.setOperator("equal");
+        ipRule.setValue(ip);
+        condition.addRule(ipRule);
+        BaseRuleDTO bkCloudIdRule = new BaseRuleDTO();
+        bkCloudIdRule.setField("bk_cloud_id");
+        bkCloudIdRule.setOperator("equal");
+        bkCloudIdRule.setValue(cloudAreaId);
+        condition.addRule(bkCloudIdRule);
         req.setCondition(condition);
 
+        List<ApplicationHostDTO> hosts = listHostsWithoutBiz(req);
+        return hosts.size() > 0 ? hosts.get(0) : null;
+    }
+
+    @Override
+    public List<ApplicationHostDTO> listHostsByIps(List<IpDTO> hostIps) {
+        ListHostsWithoutBizReq req = makeBaseReq(ListHostsWithoutBizReq.class, defaultUin, defaultSupplierAccount);
+        PropertyFilterDTO condition = new PropertyFilterDTO();
+        condition.setCondition("OR");
+        Map<Long, List<IpDTO>> hostGroups = groupHostsByCloudAreaId(hostIps);
+        hostGroups.forEach((bkCloudId, hosts) -> {
+            ComposeRuleDTO hostRule = new ComposeRuleDTO();
+            hostRule.setCondition("AND");
+            BaseRuleDTO bkCloudIdRule = new BaseRuleDTO();
+            bkCloudIdRule.setField("bk_cloud_id");
+            bkCloudIdRule.setOperator("equal");
+            bkCloudIdRule.setValue(bkCloudId);
+            hostRule.addRule(bkCloudIdRule);
+
+            BaseRuleDTO ipRule = new BaseRuleDTO();
+            ipRule.setField("bk_host_innerip");
+            ipRule.setOperator("in");
+            ipRule.setValue(hosts.stream().map(IpDTO::getIp).collect(Collectors.toList()));
+            hostRule.addRule(ipRule);
+
+            condition.addRule(hostRule);
+        });
+        req.setCondition(condition);
+
+        return listHostsWithoutBiz(req);
+    }
+
+    private List<ApplicationHostDTO> listHostsWithoutBiz(ListHostsWithoutBizReq req) {
         int limit = 1;
         int start = 0;
         PageDTO page = new PageDTO(start, limit, "");
         req.setPage(page);
-        EsbResp<ListHostsWithoutBizResult> esbResp = requestCmdbApi(HttpPost.METHOD_NAME, LIST_HOSTS_WITHOUT_BIZ
-            , req, new TypeReference<EsbResp<ListHostsWithoutBizResult>>() {
+        EsbResp<ListHostsWithoutBizResult> esbResp = requestCmdbApi(HttpPost.METHOD_NAME, LIST_HOSTS_WITHOUT_BIZ,
+            req, new TypeReference<EsbResp<ListHostsWithoutBizResult>>() {
             });
         ListHostsWithoutBizResult pageData = esbResp.getData();
         if (esbResp.getData() == null || CollectionUtils.isEmpty(esbResp.getData().getInfo())) {
-            return null;
+            return Collections.emptyList();
         }
-        return convertHost(-1L, pageData.getInfo().get(0));
+
+        List<ApplicationHostDTO> hosts =
+            pageData.getInfo().stream().map(host -> convertHost(-1, host)).collect(Collectors.toList());
+
+        // 设置主机业务信息
+        setBizRelationInfo(hosts);
+
+        return hosts;
+    }
+
+    private void setBizRelationInfo(List<ApplicationHostDTO> hosts) {
+        List<Long> hostIds = hosts.stream().map(ApplicationHostDTO::getHostId).collect(Collectors.toList());
+        List<HostBizRelationDTO> hostBizRelations = findHostBizRelations(null, hostIds);
+        Map<Long, List<HostBizRelationDTO>> hostBizRelationMap =
+            hostBizRelations.stream().collect(
+                Collectors.groupingBy(HostBizRelationDTO::getHostId));
+        // 设置bizId/moduleId/setId
+        hosts.forEach(host -> {
+            List<HostBizRelationDTO> relations = hostBizRelationMap.get(host.getHostId());
+            if (CollectionUtils.isEmpty(relations)) {
+                return;
+            }
+            host.setBizId(relations.get(0).getBizId());
+            List<Long> moduleIds = new ArrayList<>();
+            List<Long> setIds = new ArrayList<>();
+            relations.forEach(relation -> {
+                moduleIds.add(relation.getModuleId());
+                setIds.add(relation.getSetId());
+            });
+            host.setModuleId(moduleIds);
+            host.setSetId(setIds);
+        });
+    }
+
+    private Map<Long, List<IpDTO>> groupHostsByCloudAreaId(List<IpDTO> hostIps) {
+        return hostIps.stream().collect(Collectors.groupingBy(IpDTO::getCloudAreaId));
     }
 
     @Override

--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/IBizCmdbClient.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/IBizCmdbClient.java
@@ -34,7 +34,7 @@ import com.tencent.bk.job.common.cc.model.InstanceTopologyDTO;
 import com.tencent.bk.job.common.cc.model.req.GetTopoNodePathReq;
 import com.tencent.bk.job.common.cc.model.req.input.GetHostByIpInput;
 import com.tencent.bk.job.common.cc.model.result.BizEventDetail;
-import com.tencent.bk.job.common.cc.model.result.FindHostBizRelationsResult;
+import com.tencent.bk.job.common.cc.model.result.HostBizRelationDTO;
 import com.tencent.bk.job.common.cc.model.result.HostEventDetail;
 import com.tencent.bk.job.common.cc.model.result.HostRelationEventDetail;
 import com.tencent.bk.job.common.cc.model.result.ResourceWatchResult;
@@ -156,6 +156,14 @@ public interface IBizCmdbClient {
     ApplicationHostDTO getHostByIp(Long cloudAreaId, String ip);
 
     /**
+     * 根据IP批量获取主机
+     *
+     * @param hostIps 云区域+IP列表
+     * @return 主机列表
+     */
+    List<ApplicationHostDTO> listHostsByIps(List<IpDTO> hostIps);
+
+    /**
      * 批量获取业务下的主机列表
      *
      * @param bizId  cmdb业务ID
@@ -164,7 +172,7 @@ public interface IBizCmdbClient {
      */
     List<ApplicationHostDTO> listBizHosts(long bizId, Collection<IpDTO> ipList);
 
-    List<FindHostBizRelationsResult> findHostBizRelations(String uin, List<Long> hostIdList);
+    List<HostBizRelationDTO> findHostBizRelations(String uin, List<Long> hostIdList);
 
     /**
      * 获取CMDB对象属性信息列表

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/manager/host/HostCache.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/manager/host/HostCache.java
@@ -105,6 +105,15 @@ public class HostCache {
         redisTemplate.opsForValue().set(hostKey, cacheHost, 1, TimeUnit.DAYS);
     }
 
+    /**
+     * 批量更新缓存中的主机
+     *
+     * @param hosts 主机列表
+     */
+    public void addOrUpdateHosts(List<ApplicationHostDTO> hosts) {
+        hosts.forEach(this::addOrUpdateHost);
+    }
+
     private String buildHostKey(ApplicationHostDTO applicationHostDTO) {
         return buildHostKey(applicationHostDTO.getCloudAreaId(),
             applicationHostDTO.getIp());

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/HostService.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/HostService.java
@@ -194,7 +194,7 @@ public interface HostService {
     List<IpDTO> checkAppHosts(Long appId, List<IpDTO> hostIps);
 
     /**
-     * 根据主机IP批量获取主机
+     * 根据主机IP批量获取主机。如果在同步的主机中不存在，那么从cmdb查询
      *
      * @param hostIps 主机IP
      * @return 主机

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/HostServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/HostServiceImpl.java
@@ -1385,7 +1385,7 @@ public class HostServiceImpl implements HostService {
         List<ApplicationHostDTO> appHosts = applicationHostDAO.listHosts(notExistHosts);
         if (CollectionUtils.isNotEmpty(appHosts)) {
             for (ApplicationHostDTO appHost : appHosts) {
-                if (appHost.getBizId() == null) {
+                if (appHost.getBizId() == null || appHost.getBizId() < 0) {
                     log.info("Host: {} missing bizId, skip!", appHost.getCloudIp());
                     // DB中缓存的主机可能没有业务信息(依赖的主机事件还没有处理),那么暂时跳过该主机
                     continue;

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/HostServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/HostServiceImpl.java
@@ -1324,9 +1324,14 @@ public class HostServiceImpl implements HostService {
         // 从缓存中查询主机信息，并判断主机是否在业务下
         checkCachedHosts(hostIps, includeBizIds, hostsInOtherApp, notExistHosts);
 
-        // 如果主机不在缓存中，那么进一步从DB查询主，并判断主机是否在业务下
+        // 如果主机不在缓存中，那么从已同步到Job的主机中查询
         if (CollectionUtils.isNotEmpty(notExistHosts)) {
-            checkNotCachedHosts(includeBizIds, hostsInOtherApp, notExistHosts);
+            checkSyncHosts(includeBizIds, hostsInOtherApp, notExistHosts);
+        }
+
+        // 如果主机不在已同步到Job的主机中, 那么从cmdb直接查询
+        if (CollectionUtils.isNotEmpty(notExistHosts)) {
+            checkHostsFromCmdb(includeBizIds, hostsInOtherApp, notExistHosts);
         }
 
         List<IpDTO> invalidHosts = new ArrayList<>();
@@ -1365,7 +1370,7 @@ public class HostServiceImpl implements HostService {
             CacheHostDO cacheHost = cacheHosts.get(i);
             if (cacheHost != null) {
                 if (!includeBizIds.contains(cacheHost.getBizId())) {
-                    hostsInOtherApp.add(new BasicAppHost(cacheHost.getAppId(), cacheHost.getBizId(),
+                    hostsInOtherApp.add(new BasicAppHost(cacheHost.getBizId(),
                         cacheHost.getCloudAreaId(), cacheHost.getIp()));
                 }
             } else {
@@ -1374,20 +1379,54 @@ public class HostServiceImpl implements HostService {
         }
     }
 
-    private void checkNotCachedHosts(List<Long> includeBizIds,
-                                     List<BasicAppHost> hostsInOtherApp,
-                                     List<IpDTO> notExistHosts) {
+    private void checkSyncHosts(List<Long> includeBizIds,
+                                List<BasicAppHost> hostsInOtherApp,
+                                List<IpDTO> notExistHosts) {
         List<ApplicationHostDTO> appHosts = applicationHostDAO.listHosts(notExistHosts);
         if (CollectionUtils.isNotEmpty(appHosts)) {
             for (ApplicationHostDTO appHost : appHosts) {
+                if (appHost.getBizId() == null) {
+                    log.info("Host: {} missing bizId, skip!", appHost.getCloudIp());
+                    // DB中缓存的主机可能没有业务信息(依赖的主机事件还没有处理),那么暂时跳过该主机
+                    continue;
+                }
                 IpDTO hostIp = new IpDTO(appHost.getCloudAreaId(), appHost.getIp());
                 notExistHosts.remove(hostIp);
                 hostCache.addOrUpdateHost(appHost);
                 if (!includeBizIds.contains(appHost.getBizId())) {
-                    hostsInOtherApp.add(new BasicAppHost(appHost.getAppId(), appHost.getBizId(),
+                    hostsInOtherApp.add(new BasicAppHost(appHost.getBizId(),
                         appHost.getCloudAreaId(), appHost.getIp()));
                 }
             }
+        }
+    }
+
+    private void checkHostsFromCmdb(List<Long> includeBizIds,
+                                    List<BasicAppHost> hostsInOtherApp,
+                                    List<IpDTO> notExistHosts) {
+
+        IBizCmdbClient bizCmdbClient = CmdbClientFactory.getCmdbClient();
+        try {
+            List<ApplicationHostDTO> cmdbExistHosts = bizCmdbClient.listHostsByIps(notExistHosts);
+            if (CollectionUtils.isNotEmpty(cmdbExistHosts)) {
+                List<IpDTO> cmdbExistHostIps = cmdbExistHosts.stream()
+                    .map(host -> new IpDTO(host.getCloudAreaId(), host.getIp()))
+                    .collect(Collectors.toList());
+                notExistHosts.removeAll(cmdbExistHostIps);
+                log.info("sync new hosts from cmdb, hosts:{}", cmdbExistHosts);
+
+                applicationHostDAO.batchInsertAppHostInfo(dslContext, cmdbExistHosts);
+                hostCache.addOrUpdateHosts(cmdbExistHosts);
+
+                cmdbExistHosts.forEach(syncHost -> {
+                    if (!includeBizIds.contains(syncHost.getBizId())) {
+                        hostsInOtherApp.add(new BasicAppHost(syncHost.getBizId(),
+                            syncHost.getCloudAreaId(), syncHost.getIp()));
+                    }
+                });
+            }
+        } catch (Exception e) {
+            log.warn("Handle hosts that may not be synchronized from cmdb fail!", e);
         }
     }
 
@@ -1397,13 +1436,11 @@ public class HostServiceImpl implements HostService {
 
     @Data
     private static class BasicAppHost {
-        private Long appId;
         private Long bizId;
         private Long cloudAreaId;
         private String ip;
 
-        private BasicAppHost(Long appId, Long bizId, Long cloudAreaId, String ip) {
-            this.appId = appId;
+        private BasicAppHost(Long bizId, Long cloudAreaId, String ip) {
             this.bizId = bizId;
             this.cloudAreaId = cloudAreaId;
             this.ip = ip;

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/HostServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/HostServiceImpl.java
@@ -1326,11 +1326,13 @@ public class HostServiceImpl implements HostService {
 
         // 如果主机不在缓存中，那么从已同步到Job的主机中查询
         if (CollectionUtils.isNotEmpty(notExistHosts)) {
+            log.info("Hosts not in cached, check hosts by synced hosts. notCacheHosts: {}", notExistHosts);
             checkSyncHosts(includeBizIds, hostsInOtherApp, notExistHosts);
         }
 
         // 如果主机不在已同步到Job的主机中, 那么从cmdb直接查询
         if (CollectionUtils.isNotEmpty(notExistHosts)) {
+            log.info("Hosts not synced, check hosts by cmdb. notSyncedHosts: {}", notExistHosts);
             checkHostsFromCmdb(includeBizIds, hostsInOtherApp, notExistHosts);
         }
 

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/HostServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/HostServiceImpl.java
@@ -1385,7 +1385,7 @@ public class HostServiceImpl implements HostService {
         List<ApplicationHostDTO> appHosts = applicationHostDAO.listHosts(notExistHosts);
         if (CollectionUtils.isNotEmpty(appHosts)) {
             for (ApplicationHostDTO appHost : appHosts) {
-                if (appHost.getBizId() == null || appHost.getBizId() < 0) {
+                if (appHost.getBizId() == null || appHost.getBizId() <= 0) {
                     log.info("Host: {} missing bizId, skip!", appHost.getCloudIp());
                     // DB中缓存的主机可能没有业务信息(依赖的主机事件还没有处理),那么暂时跳过该主机
                     continue;

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/HostServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/HostServiceImpl.java
@@ -1415,7 +1415,6 @@ public class HostServiceImpl implements HostService {
                 notExistHosts.removeAll(cmdbExistHostIps);
                 log.info("sync new hosts from cmdb, hosts:{}", cmdbExistHosts);
 
-                applicationHostDAO.batchInsertAppHostInfo(dslContext, cmdbExistHosts);
                 hostCache.addOrUpdateHosts(cmdbExistHosts);
 
                 cmdbExistHosts.forEach(syncHost -> {


### PR DESCRIPTION
1. 执行判断主机与业务的关系，如果主机没有同步过来或者同步过来的主机数据不完整(主要是业务ID),那么实时从cmdb拉取主机数据进行判断
2. 重构cmdb list_hosts_without_biz 方法
3. 重构listHosts方法，新增从cmdb查询主机的逻辑