### PR TITLE
perf: 优化同步与事件机制，降低主机同步延迟 #958

### DIFF
--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/constant/JobConstants.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/constant/JobConstants.java
@@ -29,6 +29,10 @@ package com.tencent.bk.job.common.constant;
  */
 public class JobConstants {
     /**
+     * 默认云区域ID
+     */
+    public static final long DEFAULT_CLOUD_AREA_ID = 0L;
+    /**
      * 公共资源对应的业务ID(比如公共脚本)
      */
     public static final long PUBLIC_APP_ID = 0L;

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/ApplicationHostDTO.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/ApplicationHostDTO.java
@@ -31,6 +31,7 @@ import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * 主机
@@ -115,6 +116,27 @@ public class ApplicationHostDTO {
         } else {
             return cloudAreaId + ":" + ip;
         }
+    }
+
+    public String getModuleIdsStr() {
+        if (moduleId != null) {
+            return moduleId.stream().map(Object::toString).collect(Collectors.joining(","));
+        }
+        return null;
+    }
+
+    public String getSetIdsStr() {
+        if (setId != null) {
+            return setId.stream().map(Object::toString).collect(Collectors.joining(","));
+        }
+        return null;
+    }
+
+    public String getModuleTypeStr() {
+        if (moduleType != null) {
+            return moduleType.stream().map(Object::toString).collect(Collectors.joining(","));
+        }
+        return null;
     }
 
 }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/ApplicationHostDAO.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/ApplicationHostDAO.java
@@ -80,6 +80,8 @@ public interface ApplicationHostDAO {
 
     int insertAppHostInfo(DSLContext dslContext, ApplicationHostDTO applicationHostDTO);
 
+    int insertOrUpdateHost(DSLContext dslContext, ApplicationHostDTO hostDTO);
+
     int batchInsertAppHostInfo(DSLContext dslContext, List<ApplicationHostDTO> applicationHostDTOList);
 
     boolean existAppHostInfoByHostId(DSLContext dslContext, ApplicationHostDTO applicationHostDTO);

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/ApplicationHostDAO.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/ApplicationHostDAO.java
@@ -90,13 +90,27 @@ public interface ApplicationHostDAO {
 
     int batchUpdateBizHostInfoByHostId(DSLContext dslContext, List<ApplicationHostDTO> applicationHostDTOList);
 
-    int deleteBizHostInfoById(DSLContext dslContext, Long bizId, Long appHostId);
 
-    int batchDeleteBizHostInfoById(DSLContext dslContext, Long bizId, List<Long> appHostIdList);
+    int deleteBizHostInfoById(DSLContext dslContext, Long bizId, Long hostId);
 
+    /**
+     * 根据传入的业务ID与主机ID批量删除主机
+     *
+     * @param dslContext DB操作上下文
+     * @param bizId      业务ID
+     * @param hostIdList 要删除的主机ID列表
+     * @return 删除的主机数量
+     */
+    int batchDeleteBizHostInfoById(DSLContext dslContext, Long bizId, List<Long> hostIdList);
+
+    /**
+     * 删除某个业务下的全部主机，用于业务被删除后清理主机
+     *
+     * @param dslContext DB操作上下文
+     * @param bizId      业务ID
+     * @return 删除的主机数量
+     */
     int deleteBizHostInfoByBizId(DSLContext dslContext, long bizId);
-
-    int deleteBizHostInfoNotInBizs(DSLContext dslContext, Set<Long> notInBizIds);
 
     boolean existsHost(DSLContext dslContext, long bizId, String ip);
 

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/ApplicationHostDAO.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/ApplicationHostDAO.java
@@ -71,6 +71,8 @@ public interface ApplicationHostDAO {
 
     List<ApplicationHostDTO> listHostInfo(Collection<Long> bizIds, Collection<String> ips);
 
+    List<ApplicationHostDTO> listHostInfoByBizAndCloudIPs(Collection<Long> bizIds, Collection<String> cloudIPs);
+
     List<ApplicationHostDTO> listHostInfoBySourceAndIps(long cloudAreaId, Set<String> ips);
 
     PageData<ApplicationHostDTO> listHostInfoByPage(ApplicationHostDTO applicationHostInfoCondition,

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/HostTopoDAO.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/HostTopoDAO.java
@@ -41,6 +41,8 @@ public interface HostTopoDAO {
 
     int batchDeleteHostTopo(DSLContext dslContext, List<Long> hostIdList);
 
+    int batchDeleteHostTopo(DSLContext dslContext, Long bizId, List<Long> hostIdList);
+
     int countHostTopo(DSLContext dslContext, Long bizId, Long hostId);
 
     List<HostTopoDTO> listHostTopoByHostId(DSLContext dslContext, Long hostId);

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/impl/ApplicationHostDAOImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/impl/ApplicationHostDAOImpl.java
@@ -198,6 +198,16 @@ public class ApplicationHostDAOImpl implements ApplicationHostDAO {
     }
 
     @Override
+    public List<ApplicationHostDTO> listHostInfoByBizAndCloudIPs(Collection<Long> bizIds, Collection<String> cloudIPs) {
+        List<Condition> conditions = new ArrayList<>();
+        if (bizIds != null) {
+            conditions.add(TABLE.APP_ID.in(bizIds.parallelStream().map(ULong::valueOf).collect(Collectors.toList())));
+        }
+        conditions.add(TABLE.CLOUD_IP.in(cloudIPs.parallelStream().map(String::trim).collect(Collectors.toList())));
+        return listHostInfoByConditions(conditions);
+    }
+
+    @Override
     public List<ApplicationHostDTO> listHostInfoByBizIds(Collection<Long> bizIds, Long start, Long limit) {
         List<Condition> conditions = new ArrayList<>();
         conditions.add(TABLE.APP_ID.in(bizIds.parallelStream().map(ULong::valueOf).collect(Collectors.toList())));

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/model/dto/whiteip/CloudIPDTO.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/model/dto/whiteip/CloudIPDTO.java
@@ -24,6 +24,7 @@
 
 package com.tencent.bk.job.manage.model.dto.whiteip;
 
+import com.tencent.bk.job.common.model.dto.IpDTO;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -45,4 +46,12 @@ public class CloudIPDTO {
      * IP列表
      */
     private String ip;
+
+    public String getCloudIP() {
+        return cloudAreaId + ":" + ip;
+    }
+
+    public IpDTO toIpDTO() {
+        return new IpDTO(cloudAreaId, ip);
+    }
 }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/ApplicationService.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/ApplicationService.java
@@ -115,12 +115,12 @@ public interface ApplicationService {
     List<ApplicationDTO> listBizAppsByBizIds(Collection<Long> bizIds);
 
     /**
-     * 根据当前业务Id查询包含该业务的业务集
+     * 根据目标业务appId查询与该业务关联的业务集、全业务的appId（包含自身）
      *
-     * @param appId 业务ID
-     * @return 包含该业务的业务集ID列表
+     * @param appId 目标业务appId
+     * @return 与目标业务关联的业务集、全业务的appId（包含自身）
      */
-    List<Long> getBizSetAppIdsForBiz(Long appId);
+    List<Long> getRelatedAppIds(Long appId);
 
     /**
      * 根据资源范围类型获取业务列表

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/HostService.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/HostService.java
@@ -70,13 +70,13 @@ public interface HostService {
     List<Long> updateHostsInBiz(Long bizId, List<ApplicationHostDTO> hostInfoList);
 
     /**
-     * 删除业务下的主机
+     * 将主机从业务下移除但不删除
      *
-     * @param bizId      业务ID
-     * @param deleteList 主机信息
-     * @return 删除失败的主机ID
+     * @param bizId    业务ID
+     * @param hostList 主机信息
+     * @return 移除失败的主机ID
      */
-    List<Long> deleteHostsFromBiz(Long bizId, List<ApplicationHostDTO> deleteList);
+    List<Long> removeHostsFromBiz(Long bizId, List<ApplicationHostDTO> hostList);
 
     long countHostsByOsType(String osType);
 

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/HostServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/HostServiceImpl.java
@@ -1067,7 +1067,9 @@ public class HostServiceImpl implements HostService {
                 notInAppIPList.add(cloudIPDTO);
             }
         }
-        log.warn("ips not in cmdb:{}", StringUtil.concatCollection(notInCmdbIpList));
+        if (!notInCmdbIpList.isEmpty()) {
+            log.warn("ips not in cmdb:{}", StringUtil.concatCollection(notInCmdbIpList));
+        }
         notInAppIPList.addAll(notInCmdbIpList);
     }
 
@@ -1103,11 +1105,13 @@ public class HostServiceImpl implements HostService {
         List<CloudIPDTO> notInAppIPList = new ArrayList<>();
         separateNotInAppIP(appId, inputNotWhiteIPList, inAppIPList, notInAppIPList);
         // 4.不在业务下的IP打印出来
-        log.warn(
-            "ips not in app {}:{}",
-            appId,
-            StringUtil.concatCollection(notInAppIPList)
-        );
+        if (!notInAppIPList.isEmpty()) {
+            log.warn(
+                "ips not in app {}:{}",
+                appId,
+                StringUtil.concatCollection(notInAppIPList)
+            );
+        }
         // 5.查询主机详情
         List<CloudIPDTO> validIPList = new ArrayList<>(inputWhiteIPList);
         validIPList.addAll(inAppIPList);

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/HostServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/HostServiceImpl.java
@@ -80,8 +80,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jooq.DSLContext;
 import org.jooq.exception.DataAccessException;
-import org.slf4j.helpers.FormattingTuple;
-import org.slf4j.helpers.MessageFormatter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StopWatch;
@@ -1346,6 +1344,9 @@ public class HostServiceImpl implements HostService {
                     continue;
                 }
                 IpDTO hostIp = new IpDTO(appHost.getCloudAreaId(), appHost.getIp());
+                if (appHost.getBizId() == JobConstants.PUBLIC_APP_ID) {
+                    continue;
+                }
                 notExistHosts.remove(hostIp);
                 hostCache.addOrUpdateHost(appHost);
                 if (!includeBizIds.contains(appHost.getBizId())) {

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/WhiteIPServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/WhiteIPServiceImpl.java
@@ -194,7 +194,7 @@ public class WhiteIPServiceImpl implements WhiteIPService {
 
     @Override
     public List<CloudIPDTO> listWhiteIP(Long appId, ActionScopeEnum actionScope) {
-        List<Long> fullAppIds = applicationService.getBizSetAppIdsForBiz(appId);
+        List<Long> fullAppIds = applicationService.getRelatedAppIds(appId);
         log.info("appId={}, contains by fullAppIds={}", appId, fullAppIds);
         ActionScopeDTO actionScopeDTO = null;
         if (actionScope != null) {
@@ -336,17 +336,15 @@ public class WhiteIPServiceImpl implements WhiteIPService {
             cloudAreaId = record.getIpList().get(0).getCloudAreaId();
         }
         val applicationInfoList = applicationDAO.listAppsByAppIds(record.getAppIdList());
-        List<AppVO> appVOList = applicationInfoList.stream().map(it -> {
-            return new AppVO(
-                it.getId(),
-                it.getScope().getType().getValue(),
-                it.getScope().getId(),
-                it.getName(),
-                null,
-                null,
-                null
-            );
-        }).collect(Collectors.toList());
+        List<AppVO> appVOList = applicationInfoList.stream().map(it -> new AppVO(
+            it.getId(),
+            it.getScope().getType().getValue(),
+            it.getScope().getId(),
+            it.getName(),
+            null,
+            null,
+            null
+        )).collect(Collectors.toList());
         return new WhiteIPRecordVO(
             id,
             cloudAreaId,
@@ -395,9 +393,9 @@ public class WhiteIPServiceImpl implements WhiteIPService {
     @Override
     public List<String> getWhiteIPActionScopes(Long appId, String ip, Long cloudAreaId) {
         log.info("Input=({},{},{})", appId, ip, cloudAreaId);
-        // 1.找出包含当前业务的业务集与全业务
-        List<Long> fullAppIds = applicationService.getBizSetAppIdsForBiz(appId);
-        // 2.再找对应的白名单
+        // 1.找出与当前业务关联的所有appId
+        List<Long> fullAppIds = applicationService.getRelatedAppIds(appId);
+        // 2.再查对应的白名单
         return whiteIPRecordDAO.getWhiteIPActionScopes(dslContext, fullAppIds, ip, cloudAreaId);
     }
 

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/BasicAppSyncService.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/BasicAppSyncService.java
@@ -87,9 +87,11 @@ public class BasicAppSyncService {
         log.info("deleteAppFromDb:" + applicationDTO.getId());
         //先删Job业务对应主机
         if (applicationDTO.getScope().getType() == ResourceScopeTypeEnum.BIZ) {
-            applicationHostDAO.deleteBizHostInfoByBizId(
-                dslContext, Long.parseLong(applicationDTO.getScope().getId())
+            long bizId = Long.parseLong(applicationDTO.getScope().getId());
+            int deletedHostNum = applicationHostDAO.deleteBizHostInfoByBizId(
+                dslContext, bizId
             );
+            log.info("{} hosts of biz {} deleted", deletedHostNum, bizId);
         }
         //再删Job业务本身
         applicationService.deleteApp(applicationDTO.getId());

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/HostSyncService.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/HostSyncService.java
@@ -168,8 +168,8 @@ public class HostSyncService {
         watch.stop();
         watch.start("deleteHostsFromBiz");
         // 记录一次业务主机同步过程中所有更新失败的主机ID
-        // 需要删除的主机
-        List<Long> deleteFailHostIds = hostService.deleteHostsFromBiz(bizId, deleteList);
+        // 需要从业务下移除的主机
+        List<Long> removeFailHostIds = hostService.removeHostsFromBiz(bizId, deleteList);
         watch.stop();
         watch.start("insertHostsToApp");
         // 需要新增的主机
@@ -187,11 +187,11 @@ public class HostSyncService {
         log.info(
             Thread.currentThread().getName() +
                 ":Finished:Statistics:bizId={}:insertFailHostIds={}," +
-                "updateFailHostIds={},deleteFailHostIds={}",
+                "updateFailHostIds={},removeFailHostIds={}",
             bizId,
             insertFailHostIds,
             updateFailHostIds,
-            deleteFailHostIds
+            removeFailHostIds
         );
     }
 

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/HostWatchThread.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/HostWatchThread.java
@@ -167,7 +167,17 @@ public class HostWatchThread extends Thread {
             case ResourceWatchReq.EVENT_TYPE_UPDATE:
                 //去除没有IP的主机信息
                 if (StringUtils.isBlank(hostInfoDTO.getDisplayIp())) {
-                    applicationHostDAO.deleteBizHostInfoById(dslContext, null, hostInfoDTO.getHostId());
+                    int affectedRowNum = applicationHostDAO.deleteBizHostInfoById(
+                        dslContext,
+                        null,
+                        hostInfoDTO.getHostId()
+                    );
+                    log.info(
+                        "{} host deleted, id={} ,ip={}",
+                        affectedRowNum,
+                        hostInfoDTO.getHostId(),
+                        hostInfoDTO.getIp()
+                    );
                     break;
                 }
                 //找出Agent有效的IP，并设置Agent状态
@@ -212,7 +222,17 @@ public class HostWatchThread extends Thread {
                 hostCache.addOrUpdateHost(hostInfoDTO);
                 break;
             case ResourceWatchReq.EVENT_TYPE_DELETE:
-                applicationHostDAO.deleteBizHostInfoById(dslContext, null, hostInfoDTO.getHostId());
+                int affectedRowNum = applicationHostDAO.deleteBizHostInfoById(
+                    dslContext,
+                    null,
+                    hostInfoDTO.getHostId()
+                );
+                log.info(
+                    "{} host deleted, id={} ,ip={}",
+                    affectedRowNum,
+                    hostInfoDTO.getHostId(),
+                    hostInfoDTO.getIp()
+                );
                 hostCache.deleteHost(hostInfoDTO);
                 break;
             default:

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/HostWatchThread.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/HostWatchThread.java
@@ -30,6 +30,7 @@ import com.tencent.bk.job.common.cc.model.result.ResourceEvent;
 import com.tencent.bk.job.common.cc.model.result.ResourceWatchResult;
 import com.tencent.bk.job.common.cc.sdk.CmdbClientFactory;
 import com.tencent.bk.job.common.cc.sdk.IBizCmdbClient;
+import com.tencent.bk.job.common.constant.JobConstants;
 import com.tencent.bk.job.common.gse.service.QueryAgentStatusClient;
 import com.tencent.bk.job.common.model.dto.ApplicationHostDTO;
 import com.tencent.bk.job.common.redis.util.LockUtils;
@@ -201,7 +202,7 @@ public class HostWatchThread extends Thread {
                         applicationHostDAO.updateBizHostInfoByHostId(dslContext, oldHostInfoDTO.getBizId(),
                             hostInfoDTO);
                     } else {
-                        hostInfoDTO.setBizId(-1L);
+                        hostInfoDTO.setBizId(JobConstants.PUBLIC_APP_ID);
                         try {
                             applicationHostDAO.insertAppHostWithoutTopo(dslContext, hostInfoDTO);
                         } catch (DataAccessException e) {

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/HostWatchThread.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/HostWatchThread.java
@@ -220,7 +220,9 @@ public class HostWatchThread extends Thread {
                     // 从拓扑表向主机表同步拓扑数据
                     applicationHostDAO.syncHostTopo(dslContext, hostInfoDTO.getHostId());
                 }
-                hostCache.addOrUpdateHost(hostInfoDTO);
+                if (hostInfoDTO.getBizId() != null && hostInfoDTO.getBizId() > 0) {
+                    hostCache.addOrUpdateHost(hostInfoDTO);
+                }
                 break;
             case ResourceWatchReq.EVENT_TYPE_DELETE:
                 int affectedRowNum = applicationHostDAO.deleteBizHostInfoById(

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/SyncServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/SyncServiceImpl.java
@@ -121,7 +121,6 @@ public class SyncServiceImpl implements SyncService {
     private final BizSyncService bizSyncService;
     private final BizSetSyncService bizSetSyncService;
     private final HostSyncService hostSyncService;
-    private final AppHostsUpdateHelper appHostsUpdateHelper;
     private final AgentStatusSyncService agentStatusSyncService;
     private final HostCache hostCache;
     private final BizSetEventWatcher bizSetEventWatcher;
@@ -132,7 +131,6 @@ public class SyncServiceImpl implements SyncService {
                            BizSyncService bizSyncService,
                            BizSetSyncService bizSetSyncService,
                            HostSyncService hostSyncService,
-                           AppHostsUpdateHelper appHostsUpdateHelper,
                            AgentStatusSyncService agentStatusSyncService,
                            ApplicationDAO applicationDAO,
                            ApplicationHostDAO applicationHostDAO,
@@ -160,7 +158,6 @@ public class SyncServiceImpl implements SyncService {
         this.bizSyncService = bizSyncService;
         this.bizSetSyncService = bizSetSyncService;
         this.hostSyncService = hostSyncService;
-        this.appHostsUpdateHelper = appHostsUpdateHelper;
         this.agentStatusSyncService = agentStatusSyncService;
         this.hostCache = hostCache;
         this.bizSetEventWatcher = bizSetEventWatcher;
@@ -374,7 +371,7 @@ public class SyncServiceImpl implements SyncService {
         int count = 0;
         while (appInfoRetryCountPair != null && count < maxCount) {
             ApplicationDTO applicationDTO = appInfoRetryCountPair.getFirst();
-            Integer retryCount = appInfoRetryCountPair.getSecond();
+            int retryCount = appInfoRetryCountPair.getSecond();
             try {
                 if (retryCount > 0) {
                     arrangeSyncAppHostsTask(applicationDTO);
@@ -450,15 +447,8 @@ public class SyncServiceImpl implements SyncService {
                     List<ApplicationDTO> localNormalApps =
                         localApps.stream().filter(app ->
                             app.getAppType() == AppTypeEnum.NORMAL).collect(Collectors.toList());
-                    //删除已移除业务的主机，部分测试主机放在业务集下，不删除
-                    if (!localNormalApps.isEmpty()) {
-                        applicationHostDAO.deleteBizHostInfoNotInBizs(dslContext,
-                            localApps.stream().map(
-                                app -> Long.parseLong(app.getScope().getId())
-                            ).collect(Collectors.toSet()));
-                    }
-                    Long cmdbInterfaceTimeConsuming = 0L;
-                    Long writeToDBTimeConsuming = 0L;
+                    long cmdbInterfaceTimeConsuming = 0L;
+                    long writeToDBTimeConsuming = 0L;
                     List<Pair<ApplicationDTO, Future<Pair<Long, Long>>>> appFutureList = new ArrayList<>();
                     for (ApplicationDTO applicationDTO : localNormalApps) {
                         Future<Pair<Long, Long>> future = arrangeSyncAppHostsTask(applicationDTO);

--- a/support-files/kubernetes/charts/bk-job/Chart.yaml
+++ b/support-files/kubernetes/charts/bk-job/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: "bk-job"
 description: The BK-JOB is a ops script management and execution system with the capability of dealing with multiple tasks simultaneously.
 type: application
-version: 0.2.2-rc.9
-appVersion: "3.5.0-rc.11"
+version: 0.2.2-rc.10
+appVersion: "3.5.0-rc.12"
 
 dependencies:
 - name: common

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -645,7 +645,7 @@ gatewayConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-gateway
-    tag: 3.5.0-rc.11
+    tag: 3.5.0-rc.12
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -733,7 +733,7 @@ manageConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-manage
-    tag: 3.5.0-rc.11
+    tag: 3.5.0-rc.12
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -791,7 +791,7 @@ executeConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-execute
-    tag: 3.5.0-rc.11
+    tag: 3.5.0-rc.12
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -842,7 +842,7 @@ crontabConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-crontab
-    tag: 3.5.0-rc.11
+    tag: 3.5.0-rc.12
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -902,7 +902,7 @@ logsvrConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-logsvr
-    tag: 3.5.0-rc.11
+    tag: 3.5.0-rc.12
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -957,7 +957,7 @@ backupConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-backup
-    tag: 3.5.0-rc.11
+    tag: 3.5.0-rc.12
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -1007,7 +1007,7 @@ analysisConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-analysis
-    tag: 3.5.0-rc.11
+    tag: 3.5.0-rc.12
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -1057,7 +1057,7 @@ fileGatewayConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-file-gateway
-    tag: 3.5.0-rc.11
+    tag: 3.5.0-rc.12
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -1107,7 +1107,7 @@ fileWorkerConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-file-worker
-    tag: 3.5.0-rc.11
+    tag: 3.5.0-rc.12
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -1180,7 +1180,7 @@ frontendConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-frontend
-    tag: 3.5.0-rc.11
+    tag: 3.5.0-rc.12
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1
@@ -1241,7 +1241,7 @@ migration:
     # 镜像拉取仓库组织与镜像名称
     repository: "blueking/job-migration"
     # 镜像标签
-    tag: 3.5.0-rc.11
+    tag: 3.5.0-rc.12
     # 镜像拉取策略
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
1. 去除“删除不在所有业务下的主机”的逻辑；
2. 同步时不删主机，插入时冲突更新；
3. 手动输入IP校验主机时缓存未命中处理；
4. 重构部分代码；
5. 暂无业务归属的主机不写入缓存。