### PR TITLE
bugfix: 作业平台执行MySQL模板脚本地址匹配异常 #1158

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/resources/sqltask/mysql_exec_template.sh
+++ b/src/backend/job-execute/service-job-execute/src/main/resources/sqltask/mysql_exec_template.sh
@@ -38,7 +38,7 @@ timeSec=`date +'%s'`
 LOG=/tmp/result_${SCRIPT_NAME}_${timeSec}.log
 
 if [ ${PORT} -gt 0 ]; then
-    HOST_AND_PORT=`netstat -ntl | grep ${PORT} | awk '{print $4}'`
+    HOST_AND_PORT=`netstat -ntl | grep ":${PORT} " | awk '{print $4}'`
     HOST=${HOST_AND_PORT%:${PORT}}
     if [ ${HOST} = '0.0.0.0' -o ${HOST} = '::' ];then
         HOST='127.0.0.1'


### PR DESCRIPTION
缺陷场景:
在蓝鲸作业平台执行MySQL脚本的时候, 蓝鲸会通过内置的MySQL template脚本来执行用户上传的脚本。

脚本内有一个端口匹配的逻辑, 根据用户在作业平台传入的账号端口号去拼接MySQL的连接地址

[跳转至问题代码](https://github.com/Tencent/bk-job/blob/master/src/backend/job-execute/service-job-execute/src/main/resources/sqltask/mysql_exec_template.sh#L41)

`netstat -ntl | grep ${PORT} | awk '{print $4}'`

因为grep为模糊匹配, 忽略了存在类似端口开启的可能, 例如MySQL的`3306`, 脚本还可以grep到`33060`,`43306`......, 导致最后拼接的MySQL连接地址异常, 从而导致脚本执行失败。

可以通过修改grep规则简单的修复问题：`netstat -ntl | grep ":${PORT} " | awk '{print $4}'`

