### PR TITLE
perf: 优化滚动配置持久化的存储结构，易于后续扩展 #1163

### DIFF
--- a/src/backend/job-execute/boot-job-execute/src/test/java/com/tencent/bk/job/execute/dao/impl/RollingConfigDAOImplIntegrationTest.java
+++ b/src/backend/job-execute/boot-job-execute/src/test/java/com/tencent/bk/job/execute/dao/impl/RollingConfigDAOImplIntegrationTest.java
@@ -29,7 +29,8 @@ import com.tencent.bk.job.common.model.dto.HostDTO;
 import com.tencent.bk.job.execute.dao.RollingConfigDAO;
 import com.tencent.bk.job.execute.model.RollingConfigDTO;
 import com.tencent.bk.job.execute.model.db.RollingConfigDetailDO;
-import com.tencent.bk.job.execute.model.db.RollingServerBatchDO;
+import com.tencent.bk.job.execute.model.db.RollingHostsBatchDO;
+import com.tencent.bk.job.execute.model.db.StepRollingConfigDO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,7 +43,9 @@ import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -70,26 +73,27 @@ public class RollingConfigDAOImplIntegrationTest {
         assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getExpr()).isEqualTo("1 10% 100%");
         assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getMode()).isEqualTo(RollingModeEnum.PAUSE_IF_FAIL.getValue());
         assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getName()).isEqualTo("config1");
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getIncludeStepInstanceIdList()).containsSequence(100L,
-            101L, 102L, 103L);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getBatchRollingStepInstanceIdList()).containsSequence(100L,
-            102L, 103L);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getAllRollingStepInstanceIdList()).containsSequence(101L);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList()).hasSize(3);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList().get(0).getBatch()).isEqualTo(1);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList().get(0).getServers()).hasSize(1);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList().get(0).getServers().get(0).getBkCloudId()).isEqualTo(0L);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList().get(0).getServers().get(0).getIp()).isEqualTo("127.0.0.1");
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList().get(1).getBatch()).isEqualTo(2);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList().get(1).getServers()).hasSize(1);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList().get(1).getServers().get(0).getBkCloudId()).isEqualTo(0L);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList().get(1).getServers().get(0).getIp()).isEqualTo("127.0.0.2");
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList().get(2).getBatch()).isEqualTo(3);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList().get(2).getServers()).hasSize(2);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList().get(2).getServers().get(0).getBkCloudId()).isEqualTo(0L);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList().get(2).getServers().get(0).getIp()).isEqualTo("127.0.0.3");
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList().get(2).getServers().get(1).getBkCloudId()).isEqualTo(0L);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList().get(2).getServers().get(1).getIp()).isEqualTo("127.0.0.4");
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getStepRollingConfigs()).hasSize(4);
+        Map<Long, StepRollingConfigDO> stepRollingConfigs = savedTaskInstanceRollingConfig.getConfigDetail().getStepRollingConfigs();
+        assertThat(stepRollingConfigs.get(100L).isBatch()).isEqualTo(true);
+        assertThat(stepRollingConfigs.get(101L).isBatch()).isEqualTo(false);
+        assertThat(stepRollingConfigs.get(102L).isBatch()).isEqualTo(true);
+        assertThat(stepRollingConfigs.get(103L).isBatch()).isEqualTo(true);
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList()).hasSize(3);
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList().get(0).getBatch()).isEqualTo(1);
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList().get(0).getHosts()).hasSize(1);
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList().get(0).getHosts().get(0).getBkCloudId()).isEqualTo(0L);
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList().get(0).getHosts().get(0).getIp()).isEqualTo("127.0.0.1");
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList().get(1).getBatch()).isEqualTo(2);
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList().get(1).getHosts()).hasSize(1);
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList().get(1).getHosts().get(0).getBkCloudId()).isEqualTo(0L);
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList().get(1).getHosts().get(0).getIp()).isEqualTo("127.0.0.2");
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList().get(2).getBatch()).isEqualTo(3);
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList().get(2).getHosts()).hasSize(2);
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList().get(2).getHosts().get(0).getBkCloudId()).isEqualTo(0L);
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList().get(2).getHosts().get(0).getIp()).isEqualTo("127.0.0.3");
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList().get(2).getHosts().get(1).getBkCloudId()).isEqualTo(0L);
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList().get(2).getHosts().get(1).getIp()).isEqualTo("127.0.0.4");
     }
 
     @Test
@@ -108,20 +112,18 @@ public class RollingConfigDAOImplIntegrationTest {
         includeStepInstanceIdList.add(1002L);
         includeStepInstanceIdList.add(1003L);
         rollingConfig.setIncludeStepInstanceIdList(includeStepInstanceIdList);
-        List<Long> rollingBatchStepInstanceIdList = new ArrayList<>();
-        rollingBatchStepInstanceIdList.add(1000L);
-        rollingBatchStepInstanceIdList.add(1002L);
-        rollingBatchStepInstanceIdList.add(1003L);
-        rollingConfig.setBatchRollingStepInstanceIdList(rollingBatchStepInstanceIdList);
-        List<Long> rollingAllStepInstanceIdList = new ArrayList<>();
-        rollingAllStepInstanceIdList.add(1001L);
-        rollingConfig.setAllRollingStepInstanceIdList(rollingAllStepInstanceIdList);
-        List<RollingServerBatchDO> serverBatchList = new ArrayList<>();
+        Map<Long, StepRollingConfigDO> stepRollingConfigs = new HashMap<>();
+        stepRollingConfigs.put(1000L, new StepRollingConfigDO(true));
+        stepRollingConfigs.put(1001L, new StepRollingConfigDO(false));
+        stepRollingConfigs.put(1002L, new StepRollingConfigDO(true));
+        stepRollingConfigs.put(1003L, new StepRollingConfigDO(true));
+        rollingConfig.setStepRollingConfigs(stepRollingConfigs);
+        List<RollingHostsBatchDO> hostsBatchList = new ArrayList<>();
         List<HostDTO> servers = new ArrayList<>();
         servers.add(new HostDTO(0L, "127.0.0.1"));
-        RollingServerBatchDO serverBatch1 = new RollingServerBatchDO(1, servers);
-        serverBatchList.add(serverBatch1);
-        rollingConfig.setServerBatchList(serverBatchList);
+        RollingHostsBatchDO hostBatch1 = new RollingHostsBatchDO(1, servers);
+        hostsBatchList.add(hostBatch1);
+        rollingConfig.setHostsBatchList(hostsBatchList);
         taskInstanceRollingConfig.setConfigDetail(rollingConfig);
 
         long rollingConfigId = rollingConfigDAO.saveRollingConfig(taskInstanceRollingConfig);
@@ -137,15 +139,16 @@ public class RollingConfigDAOImplIntegrationTest {
         assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getExpr()).isEqualTo("10%");
         assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getMode()).isEqualTo(RollingModeEnum.PAUSE_IF_FAIL.getValue());
         assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getName()).isEqualTo("default");
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getIncludeStepInstanceIdList()).containsSequence(1000L,
-            1001L, 1002L, 1003L);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getBatchRollingStepInstanceIdList()).containsSequence(1000L,
-            1002L, 1003L);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getAllRollingStepInstanceIdList()).containsSequence(1001L);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList()).hasSize(1);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList().get(0).getBatch()).isEqualTo(1);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList().get(0).getServers().get(0).getBkCloudId()).isEqualTo(0L);
-        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getServerBatchList().get(0).getServers().get(0).getIp()).isEqualTo("127.0.0.1");
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getStepRollingConfigs()).hasSize(4);
+        Map<Long, StepRollingConfigDO> savedStepRollingConfigs = savedTaskInstanceRollingConfig.getConfigDetail().getStepRollingConfigs();
+        assertThat(savedStepRollingConfigs.get(1000L).isBatch()).isEqualTo(true);
+        assertThat(savedStepRollingConfigs.get(1001L).isBatch()).isEqualTo(false);
+        assertThat(savedStepRollingConfigs.get(1002L).isBatch()).isEqualTo(true);
+        assertThat(savedStepRollingConfigs.get(1003L).isBatch()).isEqualTo(true);
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList()).hasSize(1);
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList().get(0).getBatch()).isEqualTo(1);
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList().get(0).getHosts().get(0).getBkCloudId()).isEqualTo(0L);
+        assertThat(savedTaskInstanceRollingConfig.getConfigDetail().getHostsBatchList().get(0).getHosts().get(0).getIp()).isEqualTo("127.0.0.1");
     }
 }
 

--- a/src/backend/job-execute/boot-job-execute/src/test/resources/init_rolling_config_data.sql
+++ b/src/backend/job-execute/boot-job-execute/src/test/resources/init_rolling_config_data.sql
@@ -23,5 +23,6 @@
  */
 
 truncate table rolling_config;
-insert into job_execute.rolling_config (id,task_instance_id,config_name,config) values (1,1,'config1', '{"name":"config1","includeStepInstanceIdList":[100,101,102,103],"batchRollingStepInstanceIdList":[100,102,103],"allRollingStepInstanceIdList":[101],"mode":1,"expr":"1 10% 100%","serverBatchList":[{"batch":1,"servers":[{"cloudAreaId":0,"ip":"127.0.0.1"}]},{"batch":2,"servers":[{"cloudAreaId":0,"ip":"127.0.0.2"}]},{"batch":3,"servers":[{"cloudAreaId":0,"ip":"127.0.0.3"},{"cloudAreaId":0,"ip":"127.0.0.4"}]}]}');
+insert into job_execute.rolling_config (id,task_instance_id,config_name,config) values
+(1,1,'config1', '{"name":"config1","includeStepInstanceIdList":[100,101,102,103],"stepRollingConfigs": {"100": {"batch": true},"101": {"batch": false},"102": {"batch": true},"103": {"batch": true}},"mode":1,"expr":"1 10% 100%","hostsBatchList":[{"batch":1,"hosts":[{"cloudAreaId":0,"ip":"127.0.0.1"}]},{"batch":2,"hosts":[{"cloudAreaId":0,"ip":"127.0.0.2"}]},{"batch":3,"hosts":[{"cloudAreaId":0,"ip":"127.0.0.3"},{"cloudAreaId":0,"ip":"127.0.0.4"}]}]}');
 

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/listener/GseStepEventHandler.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/listener/GseStepEventHandler.java
@@ -46,7 +46,7 @@ import com.tencent.bk.job.execute.model.StepInstanceBaseDTO;
 import com.tencent.bk.job.execute.model.StepInstanceDTO;
 import com.tencent.bk.job.execute.model.StepInstanceRollingTaskDTO;
 import com.tencent.bk.job.execute.model.TaskInstanceDTO;
-import com.tencent.bk.job.execute.model.db.RollingServerBatchDO;
+import com.tencent.bk.job.execute.model.db.RollingHostsBatchDO;
 import com.tencent.bk.job.execute.service.FileAgentTaskService;
 import com.tencent.bk.job.execute.service.GseTaskService;
 import com.tencent.bk.job.execute.service.RollingConfigService;
@@ -265,15 +265,15 @@ public class GseStepEventHandler implements StepEventHandler {
             if (stepInstance.isRollingStep() && stepInstance.isFirstRollingBatch()) {
                 // 如果是第一批次的执行，需要初始化所有批次的agent任务（查询需要)
                 if (rollingConfig.isBatchRollingStep(stepInstanceId)) {
-                    List<RollingServerBatchDO> serverBatchList =
-                        rollingConfig.getConfigDetail().getServerBatchList();
+                    List<RollingHostsBatchDO> serverBatchList =
+                        rollingConfig.getConfigDetail().getHostsBatchList();
                     serverBatchList.forEach(serverBatch -> {
                         Integer actualExecuteCount = serverBatch.getBatch() == 1 ? executeCount : null;
                         agentTasks.addAll(buildGseAgentTasks(stepInstanceId,
                             executeCount, actualExecuteCount, serverBatch.getBatch(), gseTaskId,
-                            serverBatch.getServers(), AgentTaskStatusEnum.WAITING));
+                            serverBatch.getHosts(), AgentTaskStatusEnum.WAITING));
                     });
-                } else if (rollingConfig.isAllRollingStep(stepInstanceId)) {
+                } else {
                     // 暂时不支持，滚动执行二期需求
                     log.warn("All rolling step is not supported!");
                     throw new NotImplementedException("All rolling step is not supported",

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/model/RollingConfigDTO.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/model/RollingConfigDTO.java
@@ -26,7 +26,6 @@ package com.tencent.bk.job.execute.model;
 
 import com.tencent.bk.job.execute.model.db.RollingConfigDetailDO;
 import lombok.Data;
-import org.apache.commons.collections4.CollectionUtils;
 
 /**
  * 作业滚动配置实例
@@ -54,23 +53,12 @@ public class RollingConfigDTO {
     private RollingConfigDetailDO configDetail;
 
     /**
-     * 判断是否分批滚动步骤
+     * 步骤是否分批执行
      *
      * @param stepInstanceId 步骤实例ID
      */
     public boolean isBatchRollingStep(long stepInstanceId) {
-        return configDetail != null && CollectionUtils.isNotEmpty(configDetail.getBatchRollingStepInstanceIdList())
-            && configDetail.getBatchRollingStepInstanceIdList().contains(stepInstanceId);
-    }
-
-    /**
-     * 判断是否全量滚动步骤
-     *
-     * @param stepInstanceId 步骤实例ID
-     */
-    public boolean isAllRollingStep(long stepInstanceId) {
-        return configDetail != null && CollectionUtils.isNotEmpty(configDetail.getAllRollingStepInstanceIdList())
-            && configDetail.getAllRollingStepInstanceIdList().contains(stepInstanceId);
+        return configDetail != null && configDetail.getStepRollingConfigs().get(stepInstanceId).isBatch();
     }
 }
 

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/model/db/RollingConfigDetailDO.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/model/db/RollingConfigDetailDO.java
@@ -28,14 +28,17 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.tencent.bk.job.common.annotation.PersistenceObject;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * 滚动详细配置DO
  */
 @Data
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
+@NoArgsConstructor
 @PersistenceObject
 public class RollingConfigDetailDO {
     /**
@@ -51,16 +54,11 @@ public class RollingConfigDetailDO {
     private List<Long> includeStepInstanceIdList;
 
     /**
-     * 分批滚动步骤实例ID列表
+     * 步骤滚动配置
      */
-    @JsonProperty("batchRollingStepInstanceIdList")
-    private List<Long> batchRollingStepInstanceIdList;
+    @JsonProperty("stepRollingConfigs")
+    private Map<Long, StepRollingConfigDO> stepRollingConfigs;
 
-    /**
-     * 全量滚动步骤实例ID列表
-     */
-    @JsonProperty("allRollingStepInstanceIdList")
-    private List<Long> allRollingStepInstanceIdList;
     /**
      * 滚动策略
      *
@@ -78,8 +76,8 @@ public class RollingConfigDetailDO {
     /**
      * 目标服务器滚动分批
      */
-    @JsonProperty("serverBatchList")
-    private List<RollingServerBatchDO> serverBatchList;
+    @JsonProperty("hostsBatchList")
+    private List<RollingHostsBatchDO> hostsBatchList;
 
     /**
      * 滚动总批次

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/model/db/RollingHostsBatchDO.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/model/db/RollingHostsBatchDO.java
@@ -33,13 +33,13 @@ import lombok.NoArgsConstructor;
 import java.util.List;
 
 /**
- * 滚动执行-服务器分批 DO
+ * 滚动执行-主机分批 DO
  */
 @Data
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @NoArgsConstructor
 @PersistenceObject
-public class RollingServerBatchDO {
+public class RollingHostsBatchDO {
     /**
      * 滚动执行批次
      */
@@ -47,10 +47,10 @@ public class RollingServerBatchDO {
     /**
      * 该批次的目标服务器
      */
-    private List<HostDTO> servers;
+    private List<HostDTO> hosts;
 
-    public RollingServerBatchDO(Integer batch, List<HostDTO> servers) {
+    public RollingHostsBatchDO(Integer batch, List<HostDTO> hosts) {
         this.batch = batch;
-        this.servers = servers;
+        this.hosts = hosts;
     }
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/model/db/StepRollingConfigDO.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/model/db/StepRollingConfigDO.java
@@ -1,0 +1,27 @@
+package com.tencent.bk.job.execute.model.db;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.tencent.bk.job.common.annotation.PersistenceObject;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 步骤滚动配置
+ */
+@Data
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@NoArgsConstructor
+@PersistenceObject
+public class StepRollingConfigDO {
+
+    /**
+     * 是否分批
+     */
+    @JsonProperty("batch")
+    private boolean batch;
+
+    public StepRollingConfigDO(boolean batch) {
+        this.batch = batch;
+    }
+}


### PR DESCRIPTION
1. 原先的RollingConfigDetailDO.batchRollingStepInstanceIdList 和 RollingConfigDetailDO.allRollingStepInstanceIdList ，这种表达方式不方便后面扩展
2. 每个步骤单独配置，方便后续一些只针对步骤的扩展（比如在滚动中只执行一次，或者按照条件判断是否执行等)