### PR TITLE
perf: 优化滚动发布代码与设计 #1160

### DIFF
--- a/src/backend/job-logsvr/service-job-logsvr/src/main/java/com/tencent/bk/job/logsvr/mongo/ScriptLogsCollectionLoader.java
+++ b/src/backend/job-logsvr/service-job-logsvr/src/main/java/com/tencent/bk/job/logsvr/mongo/ScriptLogsCollectionLoader.java
@@ -41,7 +41,7 @@ import java.util.List;
 public class ScriptLogsCollectionLoader extends CollectionLoaderBase {
 
     private static final String IDX_STEP_ID_EXECUTE_COUNT_HOST_ID = "stepId_executeCount_hostId";
-    private static final String IDX_STEP_EXECUTE_COUNT_IP = "stepId_executeCount_ip";
+    private static final String IDX_STEP_EXECUTE_COUNT_IP = "stepId_1_executeCount_1_ip_1";
     private static final String IDX_STEP_ID_HASHED = "stepId_hashed";
 
     @Override


### PR DESCRIPTION
1. 解决创建索引报错的问题
```
com.google.common.util.concurrent.UncheckedExecutionException: com.mongodb.MongoCommandException: Command failed with error 85 (IndexOptionsConflict): 'Index with name: stepId_executeCount_ip already exists with a different name' on server xxxxx'
```