### PR TITLE
bugfix: 文件分发任务失败重试，分发目标中包含了源主机，跟重试前的步骤不一致 #1199

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/FileGseTaskStartCommand.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/FileGseTaskStartCommand.java
@@ -256,6 +256,7 @@ public class FileGseTaskStartCommand extends AbstractGseTaskStartCommand {
         for (HostDTO sourceHost : sourceHosts) {
             AgentTaskDTO agentTask = new AgentTaskDTO(stepInstanceId, executeCount, batch, sourceHost.getHostId(),
                 sourceHost.getAgentId());
+            agentTask.setActualExecuteCount(executeCount);
             agentTask.setCloudIp(sourceHost.toCloudIp());
             agentTask.setDisplayIp(sourceHost.getDisplayIp());
             agentTask.setFileTaskMode(FileTaskModeEnum.UPLOAD);

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/listener/GseStepEventHandler.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/listener/GseStepEventHandler.java
@@ -515,56 +515,49 @@ public class GseStepEventHandler implements StepEventHandler {
 
     private void saveAgentTasksForRetryFail(StepInstanceBaseDTO stepInstance, int executeCount, Integer batch,
                                             Long gseTaskId) {
-        List<AgentTaskDTO> latestAgentTasks = listAgentTasks(stepInstance, executeCount - 1);
-        boolean isFileStep = stepInstance.isFileStep();
+        List<AgentTaskDTO> retryAgentTasks = listTargetAgentTasks(stepInstance, executeCount - 1);
 
-        for (AgentTaskDTO latestAgentTask : latestAgentTasks) {
-            latestAgentTask.setExecuteCount(executeCount);
-            if (batch != null && latestAgentTask.getBatch() != batch) {
+        for (AgentTaskDTO retryAgentTask : retryAgentTasks) {
+            retryAgentTask.setExecuteCount(executeCount);
+            if (batch != null && retryAgentTask.getBatch() != batch) {
                 continue;
             }
-            if (isFileStep && latestAgentTask.getFileTaskMode() == FileTaskModeEnum.UPLOAD) {
-                // 所有文件源主机都需要重试
-                latestAgentTask.setActualExecuteCount(executeCount);
-                latestAgentTask.resetTaskInitialStatus();
-                latestAgentTask.setGseTaskId(gseTaskId);
-            } else {
-                // 只有失败的目标主机才需要参与重试
-                if (!AgentTaskStatusEnum.isSuccess(latestAgentTask.getStatus())) {
-                    latestAgentTask.setActualExecuteCount(executeCount);
-                    latestAgentTask.resetTaskInitialStatus();
-                    latestAgentTask.setGseTaskId(gseTaskId);
-                }
+            // 只有失败的目标主机才需要参与重试
+            if (!AgentTaskStatusEnum.isSuccess(retryAgentTask.getStatus())) {
+                retryAgentTask.setActualExecuteCount(executeCount);
+                retryAgentTask.resetTaskInitialStatus();
+                retryAgentTask.setGseTaskId(gseTaskId);
             }
         }
 
-        saveAgentTasks(stepInstance, latestAgentTasks);
+        saveAgentTasks(stepInstance, retryAgentTasks);
     }
 
 
     private void saveAgentTasksForRetryAll(StepInstanceBaseDTO stepInstance, int executeCount, Integer batch,
                                            Long gseTaskId) {
-        List<AgentTaskDTO> latestAgentTasks = listAgentTasks(stepInstance, executeCount - 1);
+        List<AgentTaskDTO> retryAgentTasks = listTargetAgentTasks(stepInstance, executeCount - 1);
 
-        for (AgentTaskDTO latestAgentTask : latestAgentTasks) {
-            latestAgentTask.setExecuteCount(executeCount);
-            if (batch != null && latestAgentTask.getBatch() != batch) {
+        for (AgentTaskDTO retryAgentTask : retryAgentTasks) {
+            retryAgentTask.setExecuteCount(executeCount);
+            if (batch != null && retryAgentTask.getBatch() != batch) {
                 continue;
             }
-            latestAgentTask.setActualExecuteCount(executeCount);
-            latestAgentTask.resetTaskInitialStatus();
-            latestAgentTask.setGseTaskId(gseTaskId);
+            retryAgentTask.setActualExecuteCount(executeCount);
+            retryAgentTask.resetTaskInitialStatus();
+            retryAgentTask.setGseTaskId(gseTaskId);
         }
 
-        saveAgentTasks(stepInstance, latestAgentTasks);
+        saveAgentTasks(stepInstance, retryAgentTasks);
     }
 
-    private List<AgentTaskDTO> listAgentTasks(StepInstanceBaseDTO stepInstance, int executeCount) {
+    private List<AgentTaskDTO> listTargetAgentTasks(StepInstanceBaseDTO stepInstance, int executeCount) {
         List<AgentTaskDTO> agentTasks = Collections.emptyList();
         if (stepInstance.isScriptStep()) {
             agentTasks = scriptAgentTaskService.listAgentTasks(stepInstance.getId(), executeCount, null);
         } else if (stepInstance.isFileStep()) {
-            agentTasks = fileAgentTaskService.listAgentTasks(stepInstance.getId(), executeCount, null);
+            agentTasks = fileAgentTaskService.listAgentTasks(stepInstance.getId(), executeCount, null,
+                FileTaskModeEnum.DOWNLOAD);
         }
         return agentTasks;
     }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/listener/GseStepEventHandler.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/listener/GseStepEventHandler.java
@@ -211,18 +211,12 @@ public class GseStepEventHandler implements StepEventHandler {
             taskExecuteMQEventDispatcher.dispatchGseTaskEvent(GseTaskEvent.startGseTask(
                 stepInstance.getId(), stepInstance.getExecuteCount(), stepInstance.getBatch(), gseTaskId, null));
         } else if (stepInstance.isFileStep()) {
-            // 如果不是滚动步骤或者是第一批次滚动执行，那么需要为后续的分发阶段准备本地/第三方源文件
-            if (!stepInstance.isRollingStep() || stepInstance.isFirstRollingBatch()) {
-                if (filePrepareService.needToPrepareSourceFilesForGseTask(stepInstance)) {
-                    filePrepareService.prepareFileForGseTask(stepInstance);
-                } else {
-                    taskExecuteMQEventDispatcher.dispatchGseTaskEvent(GseTaskEvent.startGseTask(
-                        stepInstance.getId(), stepInstance.getExecuteCount(), stepInstance.getBatch(), gseTaskId,
-                        null));
-                }
+            if (filePrepareService.needToPrepareSourceFilesForGseTask(stepInstance)) {
+                filePrepareService.prepareFileForGseTask(stepInstance);
             } else {
                 taskExecuteMQEventDispatcher.dispatchGseTaskEvent(GseTaskEvent.startGseTask(
-                    stepInstance.getId(), stepInstance.getExecuteCount(), stepInstance.getBatch(), gseTaskId, null));
+                    stepInstance.getId(), stepInstance.getExecuteCount(), stepInstance.getBatch(), gseTaskId,
+                    null));
             }
         }
     }
@@ -508,15 +502,7 @@ public class GseStepEventHandler implements StepEventHandler {
             saveAgentTasksForRetryFail(stepInstance, stepInstance.getExecuteCount(), stepInstance.getBatch(),
                 gseTaskId);
 
-            if (stepInstance.isScriptStep()) {
-                taskExecuteMQEventDispatcher.dispatchGseTaskEvent(GseTaskEvent.startGseTask(stepInstanceId,
-                    stepInstance.getExecuteCount(), stepInstance.getBatch(), gseTaskId, null));
-            } else if (stepInstance.isFileStep()) {
-                // 如果不是滚动步骤或者是第一批次滚动执行，那么需要为后续的分发阶段准备本地/第三方源文件
-                if (!stepInstance.isRollingStep() || stepInstance.isFirstRollingBatch()) {
-                    filePrepareService.prepareFileForGseTask(stepInstance);
-                }
-            }
+            startGseTask(stepInstance, gseTaskId);
         } else {
             log.warn("Unsupported step instance run status for retry step, stepInstanceId={}, status={}",
                 stepInstanceId, stepStatus);
@@ -621,15 +607,7 @@ public class GseStepEventHandler implements StepEventHandler {
             saveAgentTasksForRetryAll(stepInstance, stepInstance.getExecuteCount(), stepInstance.getBatch(),
                 gseTaskId);
 
-            if (stepInstance.isScriptStep()) {
-                taskExecuteMQEventDispatcher.dispatchGseTaskEvent(GseTaskEvent.startGseTask(
-                    stepInstanceId, stepInstance.getExecuteCount(), null, gseTaskId, null));
-            } else if (stepInstance.isFileStep()) {
-                // 如果不是滚动步骤或者是第一批次滚动执行，那么需要为后续的分发阶段准备本地/第三方源文件
-                if (!stepInstance.isRollingStep() || stepInstance.isFirstRollingBatch()) {
-                    filePrepareService.prepareFileForGseTask(stepInstance);
-                }
-            }
+            startGseTask(stepInstance, gseTaskId);
         } else {
             log.warn("Unsupported step instance run status for retry step, stepInstanceId={}, status={}",
                 stepInstanceId, stepStatus);


### PR DESCRIPTION
1. 修复“文件分发任务失败重试，分发目标中包含了源主机，跟重试前的步骤不一致”的问题
2. 解决重试文件分发任务，实际上没有调度的问题
3. 修改第三方文件源分发滚动逻辑，每批次都需要准备（后续第三方文件源这块需要优化准备阶段的代码，判断文件是否存在来决定是否每次都拉取)