### PR TITLE
bugfix: 打开历史作业的执行详情页面，报"内部服务器异常" #1229

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/ScriptAgentTaskServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/ScriptAgentTaskServiceImpl.java
@@ -95,7 +95,7 @@ public class ScriptAgentTaskServiceImpl
         } else if (StringUtils.isNotEmpty(host.toCloudIp())) {
             // 根据ip查询的模式，有两种情况，数据可能在gse_script_agent_task/gse_task_ip_log表中，优先查询gse_script_agent_task
             HostDTO queryHost = getStepHostByIp(stepInstance, host.toCloudIp());
-            if (queryHost != null) {
+            if (queryHost != null && queryHost.getHostId() != null) {
                 agentTask = scriptAgentTaskDAO.getAgentTaskByHostId(stepInstance.getId(), executeCount, batch,
                     queryHost.getHostId());
             } else {


### PR DESCRIPTION
- 问题分析
见 #1229 

- 解决方案
判断作业执行详情的主机是否使用包含hostId;如果hostId=null，那么使用ip查询