### PR TITLE
bugfix: 长时间运行后，file-worker下载第三方文件源文件失败 #1346

### DIFF
--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/JobHttpClientConnectionManagerFactory.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/JobHttpClientConnectionManagerFactory.java
@@ -1,0 +1,88 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.util.http;
+
+import org.apache.http.config.ConnectionConfig;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.LayeredConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+
+import java.nio.charset.Charset;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 用于创建自定义Http连接池的工厂类
+ */
+public class JobHttpClientConnectionManagerFactory {
+
+    private static final String CHARSET = "UTF-8";
+    private static final ConnectionConfig defaultConnectionConfig = ConnectionConfig.custom()
+        .setBufferSize(102400)
+        .setCharset(Charset.forName(CHARSET))
+        .build();
+
+    /**
+     * 创建可对连接租用失败时的状态进行观测的连接池
+     *
+     * @param maxConnPerRoute  单个Route最大连接数
+     * @param maxConnTotal     最大总连接数量
+     * @param sslSocketFactory SSLSocket创建工厂
+     * @return 连接池
+     */
+    public static HttpClientConnectionManager createWatchableConnectionManager(
+        int maxConnPerRoute,
+        int maxConnTotal,
+        LayeredConnectionSocketFactory sslSocketFactory
+    ) {
+        // esb的keep-alive时间为90s，需要<90s,防止连接超时抛出org.apache.http.NoHttpResponseException:
+        // The target server failed to respond
+        // 因此，timeToLive使用34s
+        final PoolingHttpClientConnectionManager poolingmgr =
+            new WatchablePoolingHttpClientConnectionManager(
+                RegistryBuilder.<ConnectionSocketFactory>create()
+                    .register("http", PlainConnectionSocketFactory.getSocketFactory())
+                    .register("https", sslSocketFactory)
+                    .build(),
+                new WatchableManagedHttpClientConnectionFactory(),
+                null,
+                null,
+                34,
+                TimeUnit.SECONDS
+            );
+        if (defaultConnectionConfig != null) {
+            poolingmgr.setDefaultConnectionConfig(defaultConnectionConfig);
+        }
+        if (maxConnTotal > 0) {
+            poolingmgr.setMaxTotal(maxConnTotal);
+        }
+        if (maxConnPerRoute > 0) {
+            poolingmgr.setDefaultMaxPerRoute(maxConnPerRoute);
+        }
+        return poolingmgr;
+    }
+}

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/WatchableConnectionRequestProxy.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/WatchableConnectionRequestProxy.java
@@ -1,0 +1,100 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.util.http;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpClientConnection;
+import org.apache.http.conn.ConnectionPoolTimeoutException;
+import org.apache.http.conn.ConnectionRequest;
+import org.apache.http.conn.ManagedHttpClientConnection;
+import org.apache.http.conn.routing.HttpRoute;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 可观测连接租用失败时连接池状态的ConnectionRequest实现类，具体连接的获取通过内部代理对象实现
+ */
+@Slf4j
+public class WatchableConnectionRequestProxy implements ConnectionRequest {
+    private final ConnectionRequest delegate;
+    private final WatchablePoolingHttpClientConnectionManager connectionManager;
+
+    public WatchableConnectionRequestProxy(ConnectionRequest delegate,
+                                           WatchablePoolingHttpClientConnectionManager connectionManager) {
+        this.delegate = delegate;
+        this.connectionManager = connectionManager;
+    }
+
+    private void tryToLogConnectionStatus() {
+        try {
+            logConnectionStatus();
+        } catch (Throwable t) {
+            log.warn("Fail to logConnectionStatus", t);
+        }
+    }
+
+    private void logConnectionStatus() {
+        // 连接池整体状态统计数据
+        for (HttpRoute route : connectionManager.getRoutes()) {
+            log.info(
+                "http conn pool:{}:{}",
+                route,
+                connectionManager.getStats(route)
+            );
+        }
+        // 被占用的连接具体信息
+        connectionManager.enumLeasedConnections(entry -> {
+            HttpRoute route = entry.getRoute();
+            log.info(
+                "leased:route={}:connectionId={}",
+                route,
+                entry.getConnection().getId()
+            );
+        });
+    }
+
+    @Override
+    public HttpClientConnection get(long timeout,
+                                    TimeUnit timeUnit) throws InterruptedException, ExecutionException,
+        ConnectionPoolTimeoutException {
+        try {
+            HttpClientConnection connection = delegate.get(timeout, timeUnit);
+            if (connection instanceof ManagedHttpClientConnection) {
+                ManagedHttpClientConnection manageConnection = (ManagedHttpClientConnection) connection;
+                log.info("get connection success:id={}", manageConnection.getId());
+            }
+            return connection;
+        } catch (Exception e) {
+            tryToLogConnectionStatus();
+            throw e;
+        }
+    }
+
+    @Override
+    public boolean cancel() {
+        return delegate.cancel();
+    }
+}

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/WatchableConnectionRequestProxy.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/WatchableConnectionRequestProxy.java
@@ -84,7 +84,7 @@ public class WatchableConnectionRequestProxy implements ConnectionRequest {
             HttpClientConnection connection = delegate.get(timeout, timeUnit);
             if (connection instanceof ManagedHttpClientConnection) {
                 ManagedHttpClientConnection manageConnection = (ManagedHttpClientConnection) connection;
-                log.info("get connection success:id={}", manageConnection.getId());
+                log.debug("get connection success:id={}", manageConnection.getId());
             }
             return connection;
         } catch (Exception e) {

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/WatchableManagedHttpClientConnectionFactory.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/WatchableManagedHttpClientConnectionFactory.java
@@ -35,7 +35,7 @@ public class WatchableManagedHttpClientConnectionFactory extends ManagedHttpClie
     @Override
     public ManagedHttpClientConnection create(final HttpRoute route, final ConnectionConfig config) {
         ManagedHttpClientConnection connection = super.create(route, config);
-        log.info("created connection,route={},id={}", route, connection.getId());
+        log.debug("created connection,route={},id={}", route, connection.getId());
         return connection;
     }
 }

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/WatchableManagedHttpClientConnectionFactory.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/WatchableManagedHttpClientConnectionFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.util.http;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.config.ConnectionConfig;
+import org.apache.http.conn.ManagedHttpClientConnection;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.impl.conn.ManagedHttpClientConnectionFactory;
+
+@Slf4j
+public class WatchableManagedHttpClientConnectionFactory extends ManagedHttpClientConnectionFactory {
+    @Override
+    public ManagedHttpClientConnection create(final HttpRoute route, final ConnectionConfig config) {
+        ManagedHttpClientConnection connection = super.create(route, config);
+        log.info("created connection,route={},id={}", route, connection.getId());
+        return connection;
+    }
+}

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/WatchablePoolingHttpClientConnectionManager.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/WatchablePoolingHttpClientConnectionManager.java
@@ -1,0 +1,73 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.util.http;
+
+import org.apache.http.config.Registry;
+import org.apache.http.conn.ConnectionRequest;
+import org.apache.http.conn.DnsResolver;
+import org.apache.http.conn.HttpConnectionFactory;
+import org.apache.http.conn.ManagedHttpClientConnection;
+import org.apache.http.conn.SchemePortResolver;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.impl.conn.DefaultHttpClientConnectionOperator;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.pool.PoolEntryCallback;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 可对连接租用失败时连接池状态进行观测的连接池扩展类
+ * 开放enumLeased方法，重写requestConnection用于生成可观测的连接请求
+ */
+public class WatchablePoolingHttpClientConnectionManager extends PoolingHttpClientConnectionManager {
+
+    public WatchablePoolingHttpClientConnectionManager(final Registry<ConnectionSocketFactory> socketFactoryRegistry,
+                                                       final HttpConnectionFactory<HttpRoute,
+                                                           ManagedHttpClientConnection> connFactory,
+                                                       final SchemePortResolver schemePortResolver,
+                                                       final DnsResolver dnsResolver,
+                                                       final long timeToLive, final TimeUnit timeUnit) {
+        super(
+            new DefaultHttpClientConnectionOperator(socketFactoryRegistry, schemePortResolver, dnsResolver),
+            connFactory,
+            timeToLive,
+            timeUnit
+        );
+    }
+
+    public void enumLeasedConnections(PoolEntryCallback<HttpRoute, ManagedHttpClientConnection> callback) {
+        super.enumLeased(callback);
+    }
+
+    @Override
+    public ConnectionRequest requestConnection(final HttpRoute route,
+                                               final Object state) {
+        return new WatchableConnectionRequestProxy(
+            super.requestConnection(route, state),
+            this
+        );
+    }
+}


### PR DESCRIPTION
1. 自定义连接池，增加连接池连接租用失败时观测日志。