### PR TITLE
bugfix: 补充历史任务对目标IP搜索的支持能力 #1395

### DIFF
--- a/src/backend/build.gradle
+++ b/src/backend/build.gradle
@@ -113,6 +113,7 @@ ext {
     set('reflectionsVersion', "0.9.12")
     set('cronUtilsVersion', "9.1.6")
     set('otelJdbcVersion', "1.9.2-alpha")
+    set('commonsValidatorVersion', "1.6")
     if (System.getProperty("bkjobVersion")) {
         set('bkjobVersion', System.getProperty("bkjobVersion"))
         println "bkjobVersoin:" + bkjobVersion
@@ -248,6 +249,7 @@ subprojects {
             // https://github.com/ronmamo/reflections
             dependency "org.reflections:reflections:$reflectionsVersion"
             dependency "com.cronutils:cron-utils:$cronUtilsVersion"
+            dependency "commons-validator:commons-validator:$commonsValidatorVersion"
             dependency "io.opentelemetry.instrumentation:opentelemetry-jdbc:$otelJdbcVersion"
             dependencySet(group: "org.jooq", version: "$jooqVersion") {
                 entry "jooq"

--- a/src/backend/commons/common/build.gradle
+++ b/src/backend/commons/common/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'jakarta.validation:jakarta.validation-api'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'com.cronutils:cron-utils'
+    implementation 'commons-validator:commons-validator'
     compileOnly 'org.springframework:spring-web'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/ip/IpUtils.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/ip/IpUtils.java
@@ -28,6 +28,7 @@ import com.tencent.bk.job.common.model.dto.HostDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.commons.validator.routines.InetAddressValidator;
 
 import java.net.Inet4Address;
 import java.net.InetAddress;
@@ -93,6 +94,26 @@ public class IpUtils {
         }
         Matcher matcher = IP_PATTERN.matcher(ipStr);
         return matcher.matches();
+    }
+
+    /**
+     * 验证ipv6格式
+     *
+     * @param ipv6Str ipv6字符串
+     */
+    public static boolean checkIpv6(String ipv6Str) {
+        InetAddressValidator validator = InetAddressValidator.getInstance();
+        return validator.isValidInet6Address(ipv6Str);
+    }
+
+    /**
+     * 验证ipv4格式
+     *
+     * @param ipv4Str ipv4字符串
+     */
+    public static boolean checkIpv4(String ipv4Str) {
+        InetAddressValidator validator = InetAddressValidator.getInstance();
+        return validator.isValidInet4Address(ipv4Str);
     }
 
     /**

--- a/src/backend/job-backup/boot-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchivistAutoConfig.java
+++ b/src/backend/job-backup/boot-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchivistAutoConfig.java
@@ -41,6 +41,7 @@ import com.tencent.bk.job.backup.dao.impl.StepInstanceRecordDAO;
 import com.tencent.bk.job.backup.dao.impl.StepInstanceRollingTaskRecordDAO;
 import com.tencent.bk.job.backup.dao.impl.StepInstanceScriptRecordDAO;
 import com.tencent.bk.job.backup.dao.impl.StepInstanceVariableRecordDAO;
+import com.tencent.bk.job.backup.dao.impl.TaskInstanceHostRecordDAO;
 import com.tencent.bk.job.backup.dao.impl.TaskInstanceRecordDAO;
 import com.tencent.bk.job.backup.dao.impl.TaskInstanceVariableRecordDAO;
 import com.tencent.bk.job.backup.service.ArchiveProgressService;
@@ -189,6 +190,14 @@ public class ArchivistAutoConfig {
             return new RollingConfigRecordDAO(context, archiveConfig);
         }
 
+        @Bean(name = "taskInstanceHostRecordDAO")
+        public TaskInstanceHostRecordDAO taskInstanceHostRecordDAO(
+            @Qualifier("job-execute-dsl-context") DSLContext context,
+            ArchiveConfig archiveConfig) {
+            log.info("Init TaskInstanceHostRecordDAO");
+            return new TaskInstanceHostRecordDAO(context, archiveConfig);
+        }
+
     }
 
     @Bean(name = "execute-archive-dao")
@@ -217,6 +226,7 @@ public class ArchivistAutoConfig {
         @Autowired(required = false) GseFileAgentTaskRecordDAO gseFileAgentTaskRecordDAO,
         @Autowired(required = false) StepInstanceRollingTaskRecordDAO stepInstanceRollingTaskRecordDAO,
         @Autowired(required = false) RollingConfigRecordDAO rollingConfigRecordDAO,
+        @Autowired(required = false) TaskInstanceHostRecordDAO taskInstanceHostRecordDAO,
         @Autowired(required = false) ExecuteArchiveDAO executeArchiveDAO,
         ArchiveProgressService archiveProgressService,
         @Qualifier("archiveExecutor") ExecutorService archiveExecutor,
@@ -240,6 +250,7 @@ public class ArchivistAutoConfig {
             gseFileAgentTaskRecordDAO,
             stepInstanceRollingTaskRecordDAO,
             rollingConfigRecordDAO,
+            taskInstanceHostRecordDAO,
             executeArchiveDAO,
             archiveProgressService,
             archiveConfig,

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/TaskInstanceHostArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/TaskInstanceHostArchivist.java
@@ -22,43 +22,23 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.execute.model;
+package com.tencent.bk.job.backup.archive.impl;
 
-import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
-import com.tencent.bk.job.execute.common.constants.TaskStartupModeEnum;
-import com.tencent.bk.job.execute.common.constants.TaskTypeEnum;
-import lombok.Data;
-import org.apache.commons.collections4.CollectionUtils;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
+import com.tencent.bk.job.backup.archive.AbstractArchivist;
+import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
+import com.tencent.bk.job.backup.dao.impl.TaskInstanceHostRecordDAO;
+import com.tencent.bk.job.backup.service.ArchiveProgressService;
+import org.jooq.generated.tables.records.TaskInstanceHostRecord;
 
 /**
- * 作业实例查询条件
+ * gse_task 表归档
  */
-@Data
-public class TaskInstanceQuery {
-    private Long appId;
-    private String operator;
-    private String taskName;
-    private Long taskInstanceId;
-    private Long cronTaskId;
-    private RunStatusEnum status;
-    private List<TaskStartupModeEnum> startupModes;
-    private TaskTypeEnum taskType;
-    private Long startTime;
-    private Long endTime;
-    private Long minTotalTimeMills;
-    private Long maxTotalTimeMills;
-    private String ip;
-    private String ipv6;
+public class TaskInstanceHostArchivist extends AbstractArchivist<TaskInstanceHostRecord> {
 
-    public List<Integer> getStartupModeValues() {
-        if (CollectionUtils.isNotEmpty(startupModes)) {
-            return startupModes.stream().map(TaskStartupModeEnum::getValue).collect(Collectors.toList());
-        } else {
-            return Collections.emptyList();
-        }
+    public TaskInstanceHostArchivist(TaskInstanceHostRecordDAO executeRecordDAO,
+                                     ExecuteArchiveDAO executeArchiveDAO,
+                                     ArchiveProgressService archiveProgressService) {
+        super(executeRecordDAO, executeArchiveDAO, archiveProgressService);
+        this.deleteIdStepSize = 10_000;
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/TaskInstanceHostRecordDAO.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/TaskInstanceHostRecordDAO.java
@@ -1,0 +1,27 @@
+package com.tencent.bk.job.backup.dao.impl;
+
+import com.tencent.bk.job.backup.config.ArchiveConfig;
+import org.jooq.DSLContext;
+import org.jooq.Table;
+import org.jooq.TableField;
+import org.jooq.generated.tables.TaskInstanceHost;
+import org.jooq.generated.tables.records.TaskInstanceHostRecord;
+
+public class TaskInstanceHostRecordDAO extends AbstractExecuteRecordDAO<TaskInstanceHostRecord> {
+
+    private static final TaskInstanceHost TABLE = TaskInstanceHost.TASK_INSTANCE_HOST;
+
+    public TaskInstanceHostRecordDAO(DSLContext context, ArchiveConfig archiveConfig) {
+        super(context, archiveConfig);
+    }
+
+    @Override
+    public Table<TaskInstanceHostRecord> getTable() {
+        return TABLE;
+    }
+
+    @Override
+    public TableField<TaskInstanceHostRecord, Long> getArchiveIdField() {
+        return TABLE.TASK_INSTANCE_ID;
+    }
+}

--- a/src/backend/job-execute/boot-job-execute/src/test/java/com/tencent/bk/job/execute/dao/impl/TaskInstanceDAOImplIntegrationTest.java
+++ b/src/backend/job-execute/boot-job-execute/src/test/java/com/tencent/bk/job/execute/dao/impl/TaskInstanceDAOImplIntegrationTest.java
@@ -26,6 +26,7 @@ package com.tencent.bk.job.execute.dao.impl;
 
 import com.tencent.bk.job.common.model.BaseSearchCondition;
 import com.tencent.bk.job.common.model.PageData;
+import com.tencent.bk.job.common.model.dto.HostDTO;
 import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
 import com.tencent.bk.job.execute.common.constants.TaskStartupModeEnum;
 import com.tencent.bk.job.execute.common.constants.TaskTypeEnum;
@@ -43,6 +44,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -318,6 +320,27 @@ class TaskInstanceDAOImplIntegrationTest {
         assertThat(taskInstanceDTO.getEndTime()).isNull();
         assertThat(taskInstanceDTO.getTotalTime()).isNull();
         assertThat(taskInstanceDTO.getStatus()).isEqualTo(RunStatusEnum.RUNNING);
+    }
+
+    @Test
+    void testSaveTaskInstanceHosts() {
+        long taskInstanceId = 10L;
+        HostDTO host1 = new HostDTO();
+        host1.setHostId(1L);
+        host1.setIp("127.0.0.1");
+        host1.setIpv6("0000:0000:0000:0000:0000:0000:0000:0001");
+        HostDTO host2 = new HostDTO();
+        host2.setHostId(2L);
+        host2.setIp("127.0.0.2");
+        HostDTO host3= new HostDTO();
+        host3.setHostId(3L);
+        host3.setIpv6("0000:0000:0000:0000:0000:0000:0000:0003");
+        List<HostDTO> hosts = new ArrayList<>();
+        hosts.add(host1);
+        hosts.add(host2);
+        hosts.add(host3);
+
+        taskInstanceDAO.saveTaskInstanceHosts(taskInstanceId, hosts);
     }
 
 }

--- a/src/backend/job-execute/boot-job-execute/src/test/resources/init_schema.sql
+++ b/src/backend/job-execute/boot-job-execute/src/test/resources/init_schema.sql
@@ -359,3 +359,17 @@ CREATE TABLE IF NOT EXISTS `step_instance_rolling_task`
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4;
 
+CREATE TABLE IF NOT EXISTS `task_instance_host`
+(
+    `task_instance_id` bigint(20)  NOT NULL DEFAULT '0',
+    `host_id`          bigint(20)  NOT NULL DEFAULT '0',
+    `ip`               varchar(15) DEFAULT NULL,
+    `ipv6`             varchar(46) DEFAULT NULL,
+    `row_create_time`  datetime    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `row_update_time`  datetime    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`task_instance_id`,`host_id`),
+    KEY (`ip`),
+    KEY (`ipv6`)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4;
+

--- a/src/backend/job-execute/boot-job-execute/src/test/resources/init_task_instance_data.sql
+++ b/src/backend/job-execute/boot-job-execute/src/test/resources/init_task_instance_data.sql
@@ -25,6 +25,7 @@
 truncate table task_instance;
 truncate table step_instance;
 truncate table gse_task_ip_log;
+truncate table task_instance_host;
 
 insert into job_execute.task_instance (id,app_id,task_id,cron_task_id,task_template_id,is_debug_task,name,type,operator,create_time,status,current_step_id,start_time,end_time,total_time,startup_mode,callback_url,app_code) values (1,2,1,NULL,1,0,'task1',1,'admin',1572868800000,3,11,1572868800000,1572868801000,1111,1,'http://bkjob.com','bk_monitor');
 insert into job_execute.task_instance (id,app_id,task_id,cron_task_id,task_template_id,is_debug_task,name,type,operator,create_time,status,current_step_id,start_time,end_time,total_time,startup_mode,callback_url,app_code) values (2,2,1,NULL,1,0,'task1',1,'admin',1572868860000,3,12,1572868800000,1572868861000,1222,1,'http://bkjob.com',NULL);
@@ -41,3 +42,8 @@ insert into job_execute.gse_task_ip_log (step_instance_id,execute_count,ip,statu
 insert into job_execute.gse_task_ip_log (step_instance_id,execute_count,ip,status,start_time,end_time,total_time,error_code,exit_code,tag,log_offset,display_ip,is_target,is_source) values (1,0,'0:127.0.0.2',9,1565767148000,1565767149000,1316,0,0,'succ',0,'127.0.0.2',1,0);
 insert into job_execute.gse_task_ip_log (step_instance_id,execute_count,ip,status,start_time,end_time,total_time,error_code,exit_code,tag,log_offset,display_ip,is_target,is_source) values (2,0,'0:127.0.0.2',9,1565767148000,1565767149000,1316,0,0,'succ',0,'127.0.0.2',1,0);
 insert into job_execute.gse_task_ip_log (step_instance_id,execute_count,ip,status,start_time,end_time,total_time,error_code,exit_code,tag,log_offset,display_ip,is_target,is_source) values (3,0,'0:127.0.0.1',9,1565767148000,1565767149000,1316,0,0,'succ',0,'127.0.0.1',1,0);
+
+insert into job_execute.task_instance_host (task_instance_id,host_id,ip,ipv6) values
+(1, 1, '127.0.0.1','0000:0000:0000:0000:0000:0000:0000:0001'),
+(1, 2, '127.0.0.2','0000:0000:0000:0000:0000:0000:0000:0002'),
+(2, 2, '127.0.0.2','0000:0000:0000:0000:0000:0000:0000:0002');

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/web/impl/WebTaskExecutionResultResourceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/web/impl/WebTaskExecutionResultResourceImpl.java
@@ -237,6 +237,15 @@ public class WebTaskExecutionResultResourceImpl implements WebTaskExecutionResul
         if (status != null) {
             taskQuery.setStatus(RunStatusEnum.valueOf(status));
         }
+        if (StringUtils.isNotEmpty(ip)) {
+            if (IpUtils.checkIpv4(ip)) {
+                taskQuery.setIp(ip);
+            } else if (IpUtils.checkIpv6(ip)) {
+                taskQuery.setIpv6(ip);
+            } else {
+                log.warn("Invalid ip {}", ip);
+            }
+        }
         taskQuery.setIp(ip);
         BaseSearchCondition baseSearchCondition = new BaseSearchCondition();
         baseSearchCondition.setStart(start);

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/TaskInstanceDAO.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/TaskInstanceDAO.java
@@ -26,12 +26,14 @@ package com.tencent.bk.job.execute.dao;
 
 import com.tencent.bk.job.common.model.BaseSearchCondition;
 import com.tencent.bk.job.common.model.PageData;
+import com.tencent.bk.job.common.model.dto.HostDTO;
 import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
 import com.tencent.bk.job.execute.common.constants.TaskStartupModeEnum;
 import com.tencent.bk.job.execute.common.constants.TaskTypeEnum;
 import com.tencent.bk.job.execute.model.TaskInstanceDTO;
 import com.tencent.bk.job.execute.model.TaskInstanceQuery;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -144,4 +146,13 @@ public interface TaskInstanceDAO {
     boolean hasExecuteHistory(Long appId, Long cronTaskId, Long fromTime, Long toTime);
 
     List<Long> listTaskInstanceId(Long appId, Long fromTime, Long toTime, int offset, int limit);
+
+    /**
+     * 保存作业实例与主机的关系，便于根据ip/ipv6检索作业实例
+     *
+     * @param taskInstanceId 作业实例ID
+     * @param hosts          主机列表
+     */
+    void saveTaskInstanceHosts(long taskInstanceId, Collection<HostDTO> hosts);
+
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/TaskInstanceDAOImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/TaskInstanceDAOImpl.java
@@ -26,6 +26,7 @@ package com.tencent.bk.job.execute.dao.impl;
 
 import com.tencent.bk.job.common.model.BaseSearchCondition;
 import com.tencent.bk.job.common.model.PageData;
+import com.tencent.bk.job.common.model.dto.HostDTO;
 import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
 import com.tencent.bk.job.execute.common.constants.TaskStartupModeEnum;
 import com.tencent.bk.job.execute.common.constants.TaskTypeEnum;
@@ -36,6 +37,7 @@ import com.tencent.bk.job.execute.model.TaskInstanceQuery;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jooq.BatchBindStep;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.Record;
@@ -45,9 +47,9 @@ import org.jooq.SelectSeekStep1;
 import org.jooq.SortField;
 import org.jooq.UpdateSetMoreStep;
 import org.jooq.conf.ParamType;
-import org.jooq.generated.tables.GseTaskIpLog;
 import org.jooq.generated.tables.StepInstance;
 import org.jooq.generated.tables.TaskInstance;
+import org.jooq.generated.tables.TaskInstanceHost;
 import org.jooq.generated.tables.records.TaskInstanceRecord;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -64,7 +66,8 @@ import java.util.List;
 @Slf4j
 @Repository
 public class TaskInstanceDAOImpl implements TaskInstanceDAO {
-    private static final TaskInstance TABLE = TaskInstance.TASK_INSTANCE;
+    private static final TaskInstance TASK_INSTANCE = TaskInstance.TASK_INSTANCE;
+    private static final TaskInstanceHost TASK_INSTANCE_HOST = TaskInstanceHost.TASK_INSTANCE_HOST;
     private final DSLContext ctx;
 
     @Autowired
@@ -74,10 +77,13 @@ public class TaskInstanceDAOImpl implements TaskInstanceDAO {
 
     @Override
     public Long addTaskInstance(TaskInstanceDTO taskInstance) {
-        Record record = ctx.insertInto(TABLE, TABLE.TASK_ID, TABLE.CRON_TASK_ID, TABLE.TASK_TEMPLATE_ID,
-            TABLE.IS_DEBUG_TASK, TABLE.APP_ID, TABLE.NAME, TABLE.OPERATOR, TABLE.STARTUP_MODE, TABLE.CURRENT_STEP_ID,
-            TABLE.STATUS, TABLE.START_TIME,
-            TABLE.END_TIME, TABLE.TOTAL_TIME, TABLE.CREATE_TIME, TABLE.CALLBACK_URL, TABLE.TYPE, TABLE.APP_CODE)
+        Record record = ctx.insertInto(TASK_INSTANCE, TASK_INSTANCE.TASK_ID, TASK_INSTANCE.CRON_TASK_ID,
+            TASK_INSTANCE.TASK_TEMPLATE_ID,
+            TASK_INSTANCE.IS_DEBUG_TASK, TASK_INSTANCE.APP_ID, TASK_INSTANCE.NAME, TASK_INSTANCE.OPERATOR,
+            TASK_INSTANCE.STARTUP_MODE, TASK_INSTANCE.CURRENT_STEP_ID,
+            TASK_INSTANCE.STATUS, TASK_INSTANCE.START_TIME,
+            TASK_INSTANCE.END_TIME, TASK_INSTANCE.TOTAL_TIME, TASK_INSTANCE.CREATE_TIME, TASK_INSTANCE.CALLBACK_URL,
+            TASK_INSTANCE.TYPE, TASK_INSTANCE.APP_CODE)
             .values(taskInstance.getTaskId(),
                 taskInstance.getCronTaskId(),
                 taskInstance.getTaskTemplateId(),
@@ -95,18 +101,21 @@ public class TaskInstanceDAOImpl implements TaskInstanceDAO {
                 taskInstance.getCallbackUrl(),
                 JooqDataTypeUtil.toByte(taskInstance.getType()),
                 taskInstance.getAppCode())
-            .returning(TABLE.ID).fetchOne();
-        return record.getValue(TABLE.ID);
+            .returning(TASK_INSTANCE.ID).fetchOne();
+        return record.getValue(TASK_INSTANCE.ID);
     }
 
     @Override
     public TaskInstanceDTO getTaskInstance(long taskInstanceId) {
-        Record record = ctx.select(TABLE.ID, TABLE.TASK_ID, TABLE.CRON_TASK_ID, TABLE.TASK_TEMPLATE_ID,
-            TABLE.IS_DEBUG_TASK, TABLE.APP_ID, TABLE.NAME, TABLE.OPERATOR, TABLE.STARTUP_MODE, TABLE.CURRENT_STEP_ID,
-            TABLE.STATUS,
-            TABLE.START_TIME, TABLE.END_TIME, TABLE.TOTAL_TIME, TABLE.CREATE_TIME, TABLE.CALLBACK_URL, TABLE.TYPE,
-            TABLE.APP_CODE).from(TABLE)
-            .where(TABLE.ID.eq(taskInstanceId)).fetchOne();
+        Record record = ctx.select(TASK_INSTANCE.ID, TASK_INSTANCE.TASK_ID, TASK_INSTANCE.CRON_TASK_ID,
+            TASK_INSTANCE.TASK_TEMPLATE_ID,
+            TASK_INSTANCE.IS_DEBUG_TASK, TASK_INSTANCE.APP_ID, TASK_INSTANCE.NAME, TASK_INSTANCE.OPERATOR,
+            TASK_INSTANCE.STARTUP_MODE, TASK_INSTANCE.CURRENT_STEP_ID,
+            TASK_INSTANCE.STATUS,
+            TASK_INSTANCE.START_TIME, TASK_INSTANCE.END_TIME, TASK_INSTANCE.TOTAL_TIME, TASK_INSTANCE.CREATE_TIME,
+            TASK_INSTANCE.CALLBACK_URL, TASK_INSTANCE.TYPE,
+            TASK_INSTANCE.APP_CODE).from(TASK_INSTANCE)
+            .where(TASK_INSTANCE.ID.eq(taskInstanceId)).fetchOne();
         return extractInfo(record);
     }
 
@@ -138,12 +147,15 @@ public class TaskInstanceDAOImpl implements TaskInstanceDAO {
 
     @Override
     public List<TaskInstanceDTO> getTaskInstanceByTaskId(long taskId) {
-        Result result = ctx.select(TABLE.ID, TABLE.TASK_ID, TABLE.CRON_TASK_ID, TABLE.TASK_TEMPLATE_ID,
-            TABLE.IS_DEBUG_TASK, TABLE.APP_ID, TABLE.NAME, TABLE.OPERATOR, TABLE.STARTUP_MODE, TABLE.CURRENT_STEP_ID,
-            TABLE.STATUS,
-            TABLE.START_TIME, TABLE.END_TIME, TABLE.TOTAL_TIME, TABLE.CREATE_TIME, TABLE.CALLBACK_URL, TABLE.TYPE,
-            TABLE.APP_CODE).from(TABLE)
-            .where(TABLE.TASK_ID.eq(taskId)).fetch();
+        Result result = ctx.select(TASK_INSTANCE.ID, TASK_INSTANCE.TASK_ID, TASK_INSTANCE.CRON_TASK_ID,
+            TASK_INSTANCE.TASK_TEMPLATE_ID,
+            TASK_INSTANCE.IS_DEBUG_TASK, TASK_INSTANCE.APP_ID, TASK_INSTANCE.NAME, TASK_INSTANCE.OPERATOR,
+            TASK_INSTANCE.STARTUP_MODE, TASK_INSTANCE.CURRENT_STEP_ID,
+            TASK_INSTANCE.STATUS,
+            TASK_INSTANCE.START_TIME, TASK_INSTANCE.END_TIME, TASK_INSTANCE.TOTAL_TIME, TASK_INSTANCE.CREATE_TIME,
+            TASK_INSTANCE.CALLBACK_URL, TASK_INSTANCE.TYPE,
+            TASK_INSTANCE.APP_CODE).from(TASK_INSTANCE)
+            .where(TASK_INSTANCE.TASK_ID.eq(taskId)).fetch();
         List<TaskInstanceDTO> taskInstances = new ArrayList<>();
         result.into(record -> {
             TaskInstanceDTO taskInstance = extractInfo(record);
@@ -156,22 +168,22 @@ public class TaskInstanceDAOImpl implements TaskInstanceDAO {
 
     @Override
     public void updateTaskStatus(long taskInstanceId, int status) {
-        ctx.update(TABLE).set(TABLE.STATUS, Byte.valueOf(String.valueOf(status)))
-            .where(TABLE.ID.eq(taskInstanceId))
+        ctx.update(TASK_INSTANCE).set(TASK_INSTANCE.STATUS, Byte.valueOf(String.valueOf(status)))
+            .where(TASK_INSTANCE.ID.eq(taskInstanceId))
             .execute();
     }
 
     @Override
     public void updateTaskStartTime(long taskInstanceId, Long startTime) {
-        ctx.update(TABLE).set(TABLE.START_TIME, startTime)
-            .where(TABLE.ID.eq(taskInstanceId))
+        ctx.update(TASK_INSTANCE).set(TASK_INSTANCE.START_TIME, startTime)
+            .where(TASK_INSTANCE.ID.eq(taskInstanceId))
             .execute();
     }
 
     @Override
     public void updateTaskEndTime(long taskInstanceId, Long endTime) {
-        ctx.update(TABLE).set(TABLE.END_TIME, endTime)
-            .where(TABLE.ID.eq(taskInstanceId))
+        ctx.update(TASK_INSTANCE).set(TASK_INSTANCE.END_TIME, endTime)
+            .where(TASK_INSTANCE.ID.eq(taskInstanceId))
             .execute();
     }
 
@@ -193,38 +205,38 @@ public class TaskInstanceDAOImpl implements TaskInstanceDAO {
 
     @Override
     public void updateTaskCurrentStepId(Long taskInstanceId, Long stepInstanceId) {
-        ctx.update(TABLE).set(TABLE.CURRENT_STEP_ID, stepInstanceId)
-            .where(TABLE.ID.eq(taskInstanceId))
+        ctx.update(TASK_INSTANCE).set(TASK_INSTANCE.CURRENT_STEP_ID, stepInstanceId)
+            .where(TASK_INSTANCE.ID.eq(taskInstanceId))
             .execute();
     }
 
     @Override
     public void resetTaskStatus(Long taskInstanceId) {
-        ctx.update(TABLE).setNull(TABLE.START_TIME).setNull(TABLE.END_TIME).setNull(TABLE.TOTAL_TIME)
-            .setNull(TABLE.CURRENT_STEP_ID)
-            .set(TABLE.STATUS, JooqDataTypeUtil.toByte(RunStatusEnum.BLANK.getValue()))
-            .where(TABLE.ID.eq(taskInstanceId))
+        ctx.update(TASK_INSTANCE).setNull(TASK_INSTANCE.START_TIME).setNull(TASK_INSTANCE.END_TIME).setNull(TASK_INSTANCE.TOTAL_TIME)
+            .setNull(TASK_INSTANCE.CURRENT_STEP_ID)
+            .set(TASK_INSTANCE.STATUS, JooqDataTypeUtil.toByte(RunStatusEnum.BLANK.getValue()))
+            .where(TASK_INSTANCE.ID.eq(taskInstanceId))
             .execute();
     }
 
     @Override
     public void cleanTaskEndTime(Long taskInstanceId) {
-        ctx.update(TABLE).setNull(TABLE.END_TIME).setNull(TABLE.TOTAL_TIME)
-            .where(TABLE.ID.eq(taskInstanceId))
+        ctx.update(TASK_INSTANCE).setNull(TASK_INSTANCE.END_TIME).setNull(TASK_INSTANCE.TOTAL_TIME)
+            .where(TASK_INSTANCE.ID.eq(taskInstanceId))
             .execute();
     }
 
     @Override
     public void updateTaskTotalTime(Long taskInstanceId, Long totalTime) {
-        ctx.update(TABLE).set(TABLE.TOTAL_TIME, totalTime)
-            .where(TABLE.ID.eq(taskInstanceId))
+        ctx.update(TASK_INSTANCE).set(TASK_INSTANCE.TOTAL_TIME, totalTime)
+            .where(TASK_INSTANCE.ID.eq(taskInstanceId))
             .execute();
     }
 
     @Override
     public PageData<TaskInstanceDTO> listPageTaskInstance(TaskInstanceQuery taskQuery,
                                                           BaseSearchCondition baseSearchCondition) {
-        if (StringUtils.isNotEmpty(taskQuery.getIp())) {
+        if (StringUtils.isNotEmpty(taskQuery.getIp()) || StringUtils.isNotEmpty(taskQuery.getIpv6())) {
             return listPageTaskInstanceByIp(taskQuery, baseSearchCondition);
         } else {
             return listPageTaskInstanceByBasicInfo(taskQuery, baseSearchCondition);
@@ -233,18 +245,25 @@ public class TaskInstanceDAOImpl implements TaskInstanceDAO {
 
     private PageData<TaskInstanceDTO> listPageTaskInstanceByBasicInfo(TaskInstanceQuery taskQuery,
                                                                       BaseSearchCondition baseSearchCondition) {
-        int count = getPageTaskInstanceCount(taskQuery);
-
-        Collection<SortField<?>> orderFields = new ArrayList<>();
-        orderFields.add(TABLE.CREATE_TIME.desc());
         int start = baseSearchCondition.getStartOrDefault(0);
         int length = baseSearchCondition.getLengthOrDefault(10);
-        Result<?> result = ctx.select(TABLE.ID, TABLE.TASK_ID, TABLE.CRON_TASK_ID, TABLE.TASK_TEMPLATE_ID,
-            TABLE.IS_DEBUG_TASK, TABLE.APP_ID, TABLE.NAME, TABLE.OPERATOR, TABLE.STARTUP_MODE, TABLE.CURRENT_STEP_ID,
-            TABLE.STATUS,
-            TABLE.START_TIME, TABLE.END_TIME, TABLE.TOTAL_TIME, TABLE.CREATE_TIME, TABLE.CALLBACK_URL, TABLE.TYPE,
-            TABLE.APP_CODE)
-            .from(TaskInstanceDAOImpl.TABLE)
+
+        int count = getPageTaskInstanceCount(taskQuery);
+        if (count == 0) {
+            return PageData.emptyPageData(start, length);
+        }
+
+        Collection<SortField<?>> orderFields = new ArrayList<>();
+        orderFields.add(TASK_INSTANCE.CREATE_TIME.desc());
+        Result<?> result = ctx.select(TASK_INSTANCE.ID, TASK_INSTANCE.TASK_ID, TASK_INSTANCE.CRON_TASK_ID,
+            TASK_INSTANCE.TASK_TEMPLATE_ID,
+            TASK_INSTANCE.IS_DEBUG_TASK, TASK_INSTANCE.APP_ID, TASK_INSTANCE.NAME, TASK_INSTANCE.OPERATOR,
+            TASK_INSTANCE.STARTUP_MODE, TASK_INSTANCE.CURRENT_STEP_ID,
+            TASK_INSTANCE.STATUS,
+            TASK_INSTANCE.START_TIME, TASK_INSTANCE.END_TIME, TASK_INSTANCE.TOTAL_TIME, TASK_INSTANCE.CREATE_TIME,
+            TASK_INSTANCE.CALLBACK_URL, TASK_INSTANCE.TYPE,
+            TASK_INSTANCE.APP_CODE)
+            .from(TaskInstanceDAOImpl.TASK_INSTANCE)
             .where(buildSearchCondition(taskQuery))
             .orderBy(orderFields)
             .limit(start, length)
@@ -255,24 +274,32 @@ public class TaskInstanceDAOImpl implements TaskInstanceDAO {
     private PageData<TaskInstanceDTO> listPageTaskInstanceByIp(TaskInstanceQuery taskQuery,
                                                                BaseSearchCondition baseSearchCondition) {
         List<Condition> conditions = buildSearchCondition(taskQuery);
-        conditions.add(GseTaskIpLog.GSE_TASK_IP_LOG.DISPLAY_IP.eq(taskQuery.getIp()));
-        int count = ctx.selectCount().from(TaskInstance.TASK_INSTANCE)
-            .leftJoin(StepInstance.STEP_INSTANCE).on(TaskInstance.TASK_INSTANCE.ID.eq(StepInstance.STEP_INSTANCE.TASK_INSTANCE_ID))
-            .leftJoin(GseTaskIpLog.GSE_TASK_IP_LOG).on(GseTaskIpLog.GSE_TASK_IP_LOG.STEP_INSTANCE_ID.eq(StepInstance.STEP_INSTANCE.ID))
-            .where(conditions)
-            .fetchOne(0, Integer.class);
-        Collection<SortField<?>> orderFields = new ArrayList<>();
-        orderFields.add(TABLE.ID.desc());
+        if (StringUtils.isNotEmpty(taskQuery.getIp())) {
+            conditions.add(TASK_INSTANCE_HOST.IP.eq(taskQuery.getIp()));
+        } else {
+            conditions.add(TASK_INSTANCE_HOST.IPV6.eq(taskQuery.getIpv6()));
+        }
         int start = baseSearchCondition.getStartOrDefault(0);
         int length = baseSearchCondition.getLengthOrDefault(10);
-        Result result = ctx.select(TABLE.ID, TABLE.TASK_ID, TABLE.CRON_TASK_ID, TABLE.TASK_TEMPLATE_ID,
-            TABLE.IS_DEBUG_TASK, TABLE.APP_ID, TABLE.NAME, TABLE.OPERATOR, TABLE.STARTUP_MODE, TABLE.CURRENT_STEP_ID,
-            TABLE.STATUS,
-            TABLE.START_TIME, TABLE.END_TIME, TABLE.TOTAL_TIME, TABLE.CREATE_TIME, TABLE.CALLBACK_URL, TABLE.TYPE,
-            TABLE.APP_CODE, GseTaskIpLog.GSE_TASK_IP_LOG.DISPLAY_IP)
-            .from(TaskInstanceDAOImpl.TABLE)
-            .leftJoin(StepInstance.STEP_INSTANCE).on(TaskInstance.TASK_INSTANCE.ID.eq(StepInstance.STEP_INSTANCE.TASK_INSTANCE_ID))
-            .leftJoin(GseTaskIpLog.GSE_TASK_IP_LOG).on(GseTaskIpLog.GSE_TASK_IP_LOG.STEP_INSTANCE_ID.eq(StepInstance.STEP_INSTANCE.ID))
+        int count = ctx.selectCount().from(TaskInstance.TASK_INSTANCE)
+            .leftJoin(TASK_INSTANCE_HOST).on(TaskInstance.TASK_INSTANCE.ID.eq(TASK_INSTANCE_HOST.TASK_INSTANCE_ID))
+            .where(conditions)
+            .fetchOne(0, Integer.class);
+        if (count == 0) {
+            return PageData.emptyPageData(start, length);
+        }
+        Collection<SortField<?>> orderFields = new ArrayList<>();
+        orderFields.add(TASK_INSTANCE.ID.desc());
+        Result result = ctx.select(TASK_INSTANCE.ID, TASK_INSTANCE.TASK_ID, TASK_INSTANCE.CRON_TASK_ID,
+            TASK_INSTANCE.TASK_TEMPLATE_ID,
+            TASK_INSTANCE.IS_DEBUG_TASK, TASK_INSTANCE.APP_ID, TASK_INSTANCE.NAME, TASK_INSTANCE.OPERATOR,
+            TASK_INSTANCE.STARTUP_MODE, TASK_INSTANCE.CURRENT_STEP_ID,
+            TASK_INSTANCE.STATUS,
+            TASK_INSTANCE.START_TIME, TASK_INSTANCE.END_TIME, TASK_INSTANCE.TOTAL_TIME, TASK_INSTANCE.CREATE_TIME,
+            TASK_INSTANCE.CALLBACK_URL, TASK_INSTANCE.TYPE,
+            TASK_INSTANCE.APP_CODE)
+            .from(TaskInstanceDAOImpl.TASK_INSTANCE)
+            .leftJoin(TASK_INSTANCE_HOST).on(TaskInstance.TASK_INSTANCE.ID.eq(TASK_INSTANCE_HOST.TASK_INSTANCE_ID))
             .where(conditions)
             .groupBy(TaskInstance.TASK_INSTANCE.ID)
             .orderBy(orderFields)
@@ -297,57 +324,57 @@ public class TaskInstanceDAOImpl implements TaskInstanceDAO {
     @SuppressWarnings("all")
     private int getPageTaskInstanceCount(TaskInstanceQuery taskQuery) {
         List<Condition> conditions = buildSearchCondition(taskQuery);
-        return ctx.selectCount().from(TABLE).where(conditions).fetchOne(0, Integer.class);
+        return ctx.selectCount().from(TASK_INSTANCE).where(conditions).fetchOne(0, Integer.class);
     }
 
     private List<Condition> buildSearchCondition(TaskInstanceQuery taskQuery) {
         List<Condition> conditions = new ArrayList<>();
-        conditions.add(TABLE.APP_ID.eq(taskQuery.getAppId()));
+        conditions.add(TASK_INSTANCE.APP_ID.eq(taskQuery.getAppId()));
         if (taskQuery.getTaskInstanceId() != null && taskQuery.getTaskInstanceId() > 0) {
-            conditions.add(TABLE.ID.eq(taskQuery.getTaskInstanceId()));
+            conditions.add(TASK_INSTANCE.ID.eq(taskQuery.getTaskInstanceId()));
             return conditions;
         }
         if (StringUtils.isNotBlank(taskQuery.getOperator())) {
-            conditions.add(TABLE.OPERATOR.eq(taskQuery.getOperator()));
+            conditions.add(TASK_INSTANCE.OPERATOR.eq(taskQuery.getOperator()));
         }
         if (StringUtils.isNotBlank(taskQuery.getTaskName())) {
-            conditions.add(TABLE.NAME.like("%" + taskQuery.getTaskName() + "%"));
+            conditions.add(TASK_INSTANCE.NAME.like("%" + taskQuery.getTaskName() + "%"));
         }
         if (taskQuery.getStatus() != null) {
-            conditions.add(TABLE.STATUS.eq(JooqDataTypeUtil.toByte(taskQuery.getStatus().getValue())));
+            conditions.add(TASK_INSTANCE.STATUS.eq(JooqDataTypeUtil.toByte(taskQuery.getStatus().getValue())));
         }
         if (CollectionUtils.isNotEmpty(taskQuery.getStartupModes())) {
             if (taskQuery.getStartupModes().size() == 0) {
-                conditions.add(TABLE.STARTUP_MODE.eq(JooqDataTypeUtil.toByte(taskQuery.getStartupModes().get(0).getValue())));
+                conditions.add(TASK_INSTANCE.STARTUP_MODE.eq(JooqDataTypeUtil.toByte(taskQuery.getStartupModes().get(0).getValue())));
             } else {
-                conditions.add(TABLE.STARTUP_MODE.in(taskQuery.getStartupModeValues()));
+                conditions.add(TASK_INSTANCE.STARTUP_MODE.in(taskQuery.getStartupModeValues()));
             }
         }
         if (taskQuery.getTaskType() != null) {
-            conditions.add(TABLE.TYPE.eq(JooqDataTypeUtil.toByte(taskQuery.getTaskType().getValue())));
+            conditions.add(TASK_INSTANCE.TYPE.eq(JooqDataTypeUtil.toByte(taskQuery.getTaskType().getValue())));
         }
         if (taskQuery.getStartTime() != null) {
-            conditions.add(TABLE.CREATE_TIME.ge(taskQuery.getStartTime()));
+            conditions.add(TASK_INSTANCE.CREATE_TIME.ge(taskQuery.getStartTime()));
         }
         if (taskQuery.getEndTime() != null) {
-            conditions.add(TABLE.CREATE_TIME.le(taskQuery.getEndTime()));
+            conditions.add(TASK_INSTANCE.CREATE_TIME.le(taskQuery.getEndTime()));
         }
         if (taskQuery.getMinTotalTimeMills() != null) {
-            conditions.add(TABLE.TOTAL_TIME.greaterThan(taskQuery.getMinTotalTimeMills()));
+            conditions.add(TASK_INSTANCE.TOTAL_TIME.greaterThan(taskQuery.getMinTotalTimeMills()));
         }
         if (taskQuery.getMaxTotalTimeMills() != null) {
-            conditions.add(TABLE.TOTAL_TIME.lessOrEqual(taskQuery.getMaxTotalTimeMills()));
+            conditions.add(TASK_INSTANCE.TOTAL_TIME.lessOrEqual(taskQuery.getMaxTotalTimeMills()));
         }
         if (taskQuery.getCronTaskId() != null && taskQuery.getCronTaskId() > 0) {
-            conditions.add(TABLE.CRON_TASK_ID.eq(taskQuery.getCronTaskId()));
+            conditions.add(TASK_INSTANCE.CRON_TASK_ID.eq(taskQuery.getCronTaskId()));
         }
         return conditions;
     }
 
     @Override
     public void addCallbackUrl(long taskInstanceId, String callBackUrl) {
-        ctx.update(TABLE).set(TABLE.CALLBACK_URL, callBackUrl)
-            .where(TABLE.ID.eq(taskInstanceId))
+        ctx.update(TASK_INSTANCE).set(TASK_INSTANCE.CALLBACK_URL, callBackUrl)
+            .where(TASK_INSTANCE.ID.eq(taskInstanceId))
             .execute();
     }
 
@@ -373,7 +400,7 @@ public class TaskInstanceDAOImpl implements TaskInstanceDAO {
             .from(TABLE)
             .where(conditions)
             .orderBy(TABLE.CREATE_TIME.desc());
-        if(log.isDebugEnabled()) {
+        if (log.isDebugEnabled()) {
             log.debug("SQL=", select.getSQL(ParamType.INLINED));
         }
         Result result;
@@ -397,55 +424,55 @@ public class TaskInstanceDAOImpl implements TaskInstanceDAO {
                                         Long startTime, Long endTime, Long totalTime) {
         UpdateSetMoreStep<TaskInstanceRecord> updateSetMoreStep = null;
         if (status != null) {
-            updateSetMoreStep = ctx.update(TABLE).set(TABLE.STATUS,
+            updateSetMoreStep = ctx.update(TASK_INSTANCE).set(TASK_INSTANCE.STATUS,
                 JooqDataTypeUtil.toByte(status.getValue()));
         }
         if (currentStepId != null) {
             if (updateSetMoreStep == null) {
-                updateSetMoreStep = ctx.update(TABLE).set(TABLE.CURRENT_STEP_ID, currentStepId);
+                updateSetMoreStep = ctx.update(TASK_INSTANCE).set(TASK_INSTANCE.CURRENT_STEP_ID, currentStepId);
             } else {
-                updateSetMoreStep.set(TABLE.CURRENT_STEP_ID, currentStepId);
+                updateSetMoreStep.set(TASK_INSTANCE.CURRENT_STEP_ID, currentStepId);
             }
         }
         if (startTime != null) {
             if (updateSetMoreStep == null) {
-                updateSetMoreStep = ctx.update(TABLE).set(TABLE.START_TIME, startTime);
+                updateSetMoreStep = ctx.update(TASK_INSTANCE).set(TASK_INSTANCE.START_TIME, startTime);
             } else {
-                updateSetMoreStep.set(TABLE.START_TIME, startTime);
+                updateSetMoreStep.set(TASK_INSTANCE.START_TIME, startTime);
             }
         }
         if (endTime != null) {
             if (updateSetMoreStep == null) {
-                updateSetMoreStep = ctx.update(TABLE).set(TABLE.END_TIME, endTime);
+                updateSetMoreStep = ctx.update(TASK_INSTANCE).set(TASK_INSTANCE.END_TIME, endTime);
             } else {
-                updateSetMoreStep.set(TABLE.END_TIME, endTime);
+                updateSetMoreStep.set(TASK_INSTANCE.END_TIME, endTime);
             }
         }
         if (totalTime != null) {
             if (updateSetMoreStep == null) {
-                updateSetMoreStep = ctx.update(TABLE).set(TABLE.TOTAL_TIME, totalTime);
+                updateSetMoreStep = ctx.update(TASK_INSTANCE).set(TASK_INSTANCE.TOTAL_TIME, totalTime);
             } else {
-                updateSetMoreStep.set(TABLE.TOTAL_TIME, totalTime);
+                updateSetMoreStep.set(TASK_INSTANCE.TOTAL_TIME, totalTime);
             }
         }
         if (updateSetMoreStep == null) {
             return;
         }
-        updateSetMoreStep.where(TABLE.ID.eq(taskInstanceId)).execute();
+        updateSetMoreStep.where(TASK_INSTANCE.ID.eq(taskInstanceId)).execute();
     }
 
     @Override
     public void resetTaskExecuteInfoForRetry(long taskInstanceId) {
-        ctx.update(TABLE)
-            .setNull(TABLE.END_TIME)
-            .setNull(TABLE.TOTAL_TIME)
-            .set(TABLE.STATUS, RunStatusEnum.RUNNING.getValue().byteValue())
-            .where(TABLE.ID.eq(taskInstanceId))
+        ctx.update(TASK_INSTANCE)
+            .setNull(TASK_INSTANCE.END_TIME)
+            .setNull(TASK_INSTANCE.TOTAL_TIME)
+            .set(TASK_INSTANCE.STATUS, RunStatusEnum.RUNNING.getValue().byteValue())
+            .where(TASK_INSTANCE.ID.eq(taskInstanceId))
             .execute();
     }
 
     public Integer countTaskInstanceByConditions(Collection<Condition> conditions) {
-        return ctx.selectCount().from(TABLE)
+        return ctx.selectCount().from(TASK_INSTANCE)
             .where(conditions).fetchOne().value1();
     }
 
@@ -455,28 +482,28 @@ public class TaskInstanceDAOImpl implements TaskInstanceDAO {
                                       List<Byte> runStatusList, Long fromTime, Long toTime) {
         List<Condition> conditions = new ArrayList<>();
         if (appId != null) {
-            conditions.add(TABLE.APP_ID.eq(appId));
+            conditions.add(TASK_INSTANCE.APP_ID.eq(appId));
         }
         if (taskStartupMode != null) {
-            conditions.add(TABLE.STARTUP_MODE.eq((byte) (taskStartupMode.getValue())));
+            conditions.add(TASK_INSTANCE.STARTUP_MODE.eq((byte) (taskStartupMode.getValue())));
         }
         if (taskType != null) {
-            conditions.add(TABLE.TYPE.eq(taskType.getValue().byteValue()));
+            conditions.add(TASK_INSTANCE.TYPE.eq(taskType.getValue().byteValue()));
         }
         if (runStatusList != null) {
-            conditions.add(TABLE.STATUS.in(runStatusList));
+            conditions.add(TASK_INSTANCE.STATUS.in(runStatusList));
         }
         if (minTotalTime != null) {
-            conditions.add(TABLE.TOTAL_TIME.greaterOrEqual(minTotalTime * 1000));
+            conditions.add(TASK_INSTANCE.TOTAL_TIME.greaterOrEqual(minTotalTime * 1000));
         }
         if (maxTotalTime != null) {
-            conditions.add(TABLE.TOTAL_TIME.lessOrEqual(maxTotalTime * 1000));
+            conditions.add(TASK_INSTANCE.TOTAL_TIME.lessOrEqual(maxTotalTime * 1000));
         }
         if (fromTime != null) {
-            conditions.add(TABLE.CREATE_TIME.greaterOrEqual(fromTime));
+            conditions.add(TASK_INSTANCE.CREATE_TIME.greaterOrEqual(fromTime));
         }
         if (toTime != null) {
-            conditions.add(TABLE.CREATE_TIME.lessThan(toTime));
+            conditions.add(TASK_INSTANCE.CREATE_TIME.lessThan(toTime));
         }
         return countTaskInstanceByConditions(conditions);
     }
@@ -485,20 +512,20 @@ public class TaskInstanceDAOImpl implements TaskInstanceDAO {
     public List<Long> listTaskInstanceAppId(List<Long> inAppIdList, Long cronTaskId, Long minCreateTime) {
         List<Condition> conditions = new ArrayList<>();
         if (inAppIdList != null) {
-            conditions.add(TABLE.APP_ID.in(inAppIdList));
+            conditions.add(TASK_INSTANCE.APP_ID.in(inAppIdList));
         }
         if (cronTaskId != null) {
-            conditions.add(TABLE.CRON_TASK_ID.eq(cronTaskId));
+            conditions.add(TASK_INSTANCE.CRON_TASK_ID.eq(cronTaskId));
         }
         if (minCreateTime != null) {
-            conditions.add(TABLE.CREATE_TIME.greaterOrEqual(minCreateTime));
+            conditions.add(TASK_INSTANCE.CREATE_TIME.greaterOrEqual(minCreateTime));
         }
-        Result result = ctx.selectDistinct(TABLE.APP_ID).from(TABLE)
+        Result result = ctx.selectDistinct(TASK_INSTANCE.APP_ID).from(TASK_INSTANCE)
             .where(conditions)
             .fetch();
         List<Long> appIdList = new ArrayList<>();
         result.into(record -> {
-            Long appId = record.getValue(TABLE.APP_ID);
+            Long appId = record.getValue(TASK_INSTANCE.APP_ID);
             if (appId != null) {
                 appIdList.add(appId);
             }
@@ -510,18 +537,18 @@ public class TaskInstanceDAOImpl implements TaskInstanceDAO {
     public boolean hasExecuteHistory(Long appId, Long cronTaskId, Long fromTime, Long toTime) {
         List<Condition> conditions = new ArrayList<>();
         if (appId != null) {
-            conditions.add(TABLE.APP_ID.eq(appId));
+            conditions.add(TASK_INSTANCE.APP_ID.eq(appId));
         }
         if (cronTaskId != null) {
-            conditions.add(TABLE.CRON_TASK_ID.eq(cronTaskId));
+            conditions.add(TASK_INSTANCE.CRON_TASK_ID.eq(cronTaskId));
         }
         if (fromTime != null) {
-            conditions.add(TABLE.CREATE_TIME.greaterOrEqual(fromTime));
+            conditions.add(TASK_INSTANCE.CREATE_TIME.greaterOrEqual(fromTime));
         }
         if (toTime != null) {
-            conditions.add(TABLE.CREATE_TIME.lessOrEqual(toTime));
+            conditions.add(TASK_INSTANCE.CREATE_TIME.lessOrEqual(toTime));
         }
-        Result<Record1<Long>> result = ctx.select(TABLE.APP_ID).from(TABLE)
+        Result<Record1<Long>> result = ctx.select(TASK_INSTANCE.APP_ID).from(TASK_INSTANCE)
             .where(conditions)
             .limit(1)
             .fetch();
@@ -532,22 +559,42 @@ public class TaskInstanceDAOImpl implements TaskInstanceDAO {
     public List<Long> listTaskInstanceId(Long appId, Long fromTime, Long toTime, int offset, int limit) {
         List<Condition> conditions = new ArrayList<>();
         if (appId != null) {
-            conditions.add(TABLE.APP_ID.eq(appId));
+            conditions.add(TASK_INSTANCE.APP_ID.eq(appId));
         }
         if (fromTime != null) {
-            conditions.add(TABLE.CREATE_TIME.greaterOrEqual(fromTime));
+            conditions.add(TASK_INSTANCE.CREATE_TIME.greaterOrEqual(fromTime));
         }
         if (toTime != null) {
-            conditions.add(TABLE.CREATE_TIME.lessThan(toTime));
+            conditions.add(TASK_INSTANCE.CREATE_TIME.lessThan(toTime));
         }
-        Result<Record1<Long>> result = ctx.select(TABLE.ID).from(TABLE)
+        Result<Record1<Long>> result = ctx.select(TASK_INSTANCE.ID).from(TASK_INSTANCE)
             .where(conditions)
             .limit(offset, limit)
             .fetch();
         List<Long> taskInstanceIdList = new ArrayList<>();
         result.into(record -> {
-            taskInstanceIdList.add(record.get(TABLE.ID));
+            taskInstanceIdList.add(record.get(TASK_INSTANCE.ID));
         });
         return taskInstanceIdList;
+    }
+
+    @Override
+    public void saveTaskInstanceHosts(long taskInstanceId,
+                                      Collection<HostDTO> hosts) {
+        BatchBindStep batchInsert = ctx.batch(
+            ctx.insertInto(TASK_INSTANCE_HOST, TASK_INSTANCE_HOST.TASK_INSTANCE_ID,
+                TASK_INSTANCE_HOST.HOST_ID, TASK_INSTANCE_HOST.IP, TASK_INSTANCE_HOST.IPV6)
+                .values((Long) null, null, null, null)
+        );
+
+        for (HostDTO host : hosts) {
+            batchInsert = batchInsert.bind(
+                taskInstanceId,
+                host.getHostId(),
+                host.getIp(),
+                host.getIpv6()
+            );
+        }
+        batchInsert.execute();
     }
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/TaskInstanceService.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/TaskInstanceService.java
@@ -24,6 +24,7 @@
 
 package com.tencent.bk.job.execute.service;
 
+import com.tencent.bk.job.common.model.dto.HostDTO;
 import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
 import com.tencent.bk.job.execute.common.constants.StepExecuteTypeEnum;
 import com.tencent.bk.job.execute.common.constants.TaskStartupModeEnum;
@@ -34,6 +35,7 @@ import com.tencent.bk.job.execute.model.StepInstanceDTO;
 import com.tencent.bk.job.execute.model.TaskInstanceDTO;
 import com.tencent.bk.job.manage.common.consts.script.ScriptTypeEnum;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -231,4 +233,12 @@ public interface TaskInstanceService {
     boolean hasExecuteHistory(Long appId, Long cronTaskId, Long fromTime, Long toTime);
 
     List<Long> listTaskInstanceId(Long appId, Long fromTime, Long toTime, int offset, int limit);
+
+    /**
+     * 保存作业实例与主机的关系，便于根据ip/ipv6检索作业实例
+     *
+     * @param taskInstanceId 作业实例ID
+     * @param hosts          主机列表
+     */
+    void saveTaskInstanceHosts(long taskInstanceId, Collection<HostDTO> hosts);
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/TaskInstanceServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/TaskInstanceServiceImpl.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.execute.service.impl;
 
 import com.tencent.bk.job.common.constant.NotExistPathHandlerEnum;
+import com.tencent.bk.job.common.model.dto.HostDTO;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
 import com.tencent.bk.job.execute.common.constants.StepExecuteTypeEnum;
@@ -49,6 +50,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -392,5 +394,11 @@ public class TaskInstanceServiceImpl implements TaskInstanceService {
     @Override
     public List<Long> listTaskInstanceId(Long appId, Long fromTime, Long toTime, int offset, int limit) {
         return taskInstanceDAO.listTaskInstanceId(appId, fromTime, toTime, offset, limit);
+    }
+
+    @Override
+    public void saveTaskInstanceHosts(long taskInstanceId,
+                                      Collection<HostDTO> hosts) {
+        taskInstanceDAO.saveTaskInstanceHosts(taskInstanceId, hosts);
     }
 }

--- a/support-files/sql/job-execute/0021_job_execute_20221010-1000_V3.6.0.4_mysql.sql
+++ b/support-files/sql/job-execute/0021_job_execute_20221010-1000_V3.6.0.4_mysql.sql
@@ -1,0 +1,37 @@
+USE job_execute;
+
+SET NAMES utf8mb4;
+
+DROP PROCEDURE IF EXISTS job_schema_update;
+
+DELIMITER <JOB_UBF>
+
+CREATE PROCEDURE job_schema_update()
+BEGIN
+
+  DECLARE db VARCHAR(100);
+  SET AUTOCOMMIT = 0;
+  SELECT DATABASE() INTO db;
+
+  CREATE TABLE IF NOT EXISTS `task_instance_host` 
+  (
+    `task_instance_id` bigint(20)  NOT NULL DEFAULT '0',
+    `host_id`          bigint(20)  NOT NULL DEFAULT '0',
+    `ip`               varchar(15) DEFAULT NULL,
+    `ipv6`             varchar(46) DEFAULT NULL,
+    `row_create_time`  datetime    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `row_update_time`  datetime    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`task_instance_id`,`host_id`),
+    KEY `idx_ip` (`ip`),
+    KEY `idx_ipv6` (`ipv6`)
+  ) ENGINE=InnoDB
+    DEFAULT CHARSET=utf8mb4;
+
+  COMMIT;
+END <JOB_UBF>
+DELIMITER ;
+COMMIT;
+
+CALL job_schema_update();
+
+DROP PROCEDURE IF EXISTS job_schema_update;


### PR DESCRIPTION
1. 新增task_instance_host表，保存主机与作业的关系，用存储空间换时间
2. 之所有不用原来的task->step->agent_task这种join的方式，一方面考虑到join的表过多，影响性能（需要join的表有4张，task_instance+step_instance+gse_script_agent_task+gse_file_agent_task);另外一方面，后续可能会做分库分表的设计，用这几张表的join可能会影响分库分表）
3. 便于后续扩展；如果后面引入ES搜索，那么这张表的数据无需写入即可，比较容易废弃