### PR TITLE
bugfix: 本地文件上传大小限制/数据库账号端口可以输入负数 #1445

### DIFF
--- a/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages.properties
@@ -45,3 +45,6 @@ validation.constraints.InvalidBkScopeId.message=非法的资源范围ID
 validation.constraints.InvalidUploadFileSuffix.message=非法的上传文件后缀
 validation.constraints.InvalidUploadFileRestrictMode.message=非法的上传文件限制模式
 validation.constraints.InvalidScriptId_empty.message=脚本ID不能为空
+validation.constraints.EmptyDynamicGroupId.message=动态分组ID不可为空
+validation.constraints.InvalidFileUploadSettingAmount.message=文件大小只能为大于0的浮点数
+validation.constraints.InvalidPort.message=端口号只能为0及以上的整数

--- a/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages.properties
@@ -47,4 +47,4 @@ validation.constraints.InvalidUploadFileRestrictMode.message=非法的上传文�
 validation.constraints.InvalidScriptId_empty.message=脚本ID不能为空
 validation.constraints.EmptyDynamicGroupId.message=动态分组ID不可为空
 validation.constraints.InvalidFileUploadSettingAmount.message=文件大小只能为大于0的浮点数
-validation.constraints.InvalidPort.message=端口号只能为0及以上的整数
+validation.constraints.InvalidPort.message=端口号只能为0-65536之间的整数

--- a/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_en.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_en.properties
@@ -45,3 +45,6 @@ validation.constraints.InvalidBkScopeId.message=Invalid bk_scope_id
 validation.constraints.InvalidUploadFileSuffix.message=Invalid file suffix
 validation.constraints.InvalidUploadFileRestrictMode.message=Invalid restrict mode
 validation.constraints.InvalidScriptId_empty.message=Script id cannot be empty
+validation.constraints.EmptyDynamicGroupId.message=DynamicGroup ID cannot be empty
+validation.constraints.InvalidFileUploadSettingAmount.message=File size must be a positive float
+validation.constraints.InvalidPort.message=Port must be a integer which is equal to or greater than 0

--- a/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_en.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_en.properties
@@ -47,4 +47,4 @@ validation.constraints.InvalidUploadFileRestrictMode.message=Invalid restrict mo
 validation.constraints.InvalidScriptId_empty.message=Script id cannot be empty
 validation.constraints.EmptyDynamicGroupId.message=DynamicGroup ID cannot be empty
 validation.constraints.InvalidFileUploadSettingAmount.message=File size must be a positive float
-validation.constraints.InvalidPort.message=Port must be a integer which is equal to or greater than 0
+validation.constraints.InvalidPort.message=Port must be a integer which is between 0 and 65536

--- a/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_en_US.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_en_US.properties
@@ -45,3 +45,6 @@ validation.constraints.InvalidBkScopeId.message=Invalid bk_scope_id
 validation.constraints.InvalidUploadFileSuffix.message=Invalid file suffix
 validation.constraints.InvalidUploadFileRestrictMode.message=Invalid restrict mode
 validation.constraints.InvalidScriptId_empty.message=Script id cannot be empty
+validation.constraints.EmptyDynamicGroupId.message=DynamicGroup ID cannot be empty
+validation.constraints.InvalidFileUploadSettingAmount.message=File size must be a positive float
+validation.constraints.InvalidPort.message=Port must be a integer which is equal to or greater than 0

--- a/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_en_US.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_en_US.properties
@@ -47,4 +47,4 @@ validation.constraints.InvalidUploadFileRestrictMode.message=Invalid restrict mo
 validation.constraints.InvalidScriptId_empty.message=Script id cannot be empty
 validation.constraints.EmptyDynamicGroupId.message=DynamicGroup ID cannot be empty
 validation.constraints.InvalidFileUploadSettingAmount.message=File size must be a positive float
-validation.constraints.InvalidPort.message=Port must be a integer which is equal to or greater than 0
+validation.constraints.InvalidPort.message=Port must be a integer which is between 0 and 65536

--- a/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_zh.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_zh.properties
@@ -45,3 +45,6 @@ validation.constraints.InvalidBkScopeId.message=非法的资源范围ID
 validation.constraints.InvalidUploadFileSuffix.message=非法的上传文件后缀
 validation.constraints.InvalidUploadFileRestrictMode.message=非法的上传文件限制模式
 validation.constraints.InvalidScriptId_empty.message=脚本ID不能为空
+validation.constraints.EmptyDynamicGroupId.message=动态分组ID不可为空
+validation.constraints.InvalidFileUploadSettingAmount.message=文件大小只能为大于0的浮点数
+validation.constraints.InvalidPort.message=端口号只能为0及以上的整数

--- a/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_zh.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_zh.properties
@@ -47,4 +47,4 @@ validation.constraints.InvalidUploadFileRestrictMode.message=非法的上传文�
 validation.constraints.InvalidScriptId_empty.message=脚本ID不能为空
 validation.constraints.EmptyDynamicGroupId.message=动态分组ID不可为空
 validation.constraints.InvalidFileUploadSettingAmount.message=文件大小只能为大于0的浮点数
-validation.constraints.InvalidPort.message=端口号只能为0及以上的整数
+validation.constraints.InvalidPort.message=端口号只能为0-65536之间的整数

--- a/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_zh_CN.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_zh_CN.properties
@@ -45,3 +45,6 @@ validation.constraints.InvalidBkScopeId.message=非法的资源范围ID
 validation.constraints.InvalidUploadFileSuffix.message=非法的上传文件后缀
 validation.constraints.InvalidUploadFileRestrictMode.message=非法的上传文件限制模式
 validation.constraints.InvalidScriptId_empty.message=脚本ID不能为空
+validation.constraints.EmptyDynamicGroupId.message=动态分组ID不可为空
+validation.constraints.InvalidFileUploadSettingAmount.message=文件大小只能为大于0的浮点数
+validation.constraints.InvalidPort.message=端口号只能为0及以上的整数

--- a/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_zh_CN.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_zh_CN.properties
@@ -47,4 +47,4 @@ validation.constraints.InvalidUploadFileRestrictMode.message=非法的上传文�
 validation.constraints.InvalidScriptId_empty.message=脚本ID不能为空
 validation.constraints.EmptyDynamicGroupId.message=动态分组ID不可为空
 validation.constraints.InvalidFileUploadSettingAmount.message=文件大小只能为大于0的浮点数
-validation.constraints.InvalidPort.message=端口号只能为0及以上的整数
+validation.constraints.InvalidPort.message=端口号只能为0-65536之间的整数

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/WebAppAccountResource.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/WebAppAccountResource.java
@@ -33,6 +33,7 @@ import com.tencent.bk.job.manage.model.web.vo.AccountVO;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -71,7 +72,7 @@ public interface WebAppAccountResource {
         @PathVariable(value = "scopeId")
             String scopeId,
         @ApiParam(value = "创建账号请求")
-        @RequestBody
+        @RequestBody @Validated
             AccountCreateUpdateReq accountCreateUpdateReq
     );
 
@@ -91,7 +92,7 @@ public interface WebAppAccountResource {
         @PathVariable(value = "scopeId")
             String scopeId,
         @ApiParam(value = "更新账号请求")
-        @RequestBody
+        @RequestBody @Validated
             AccountCreateUpdateReq accountCreateUpdateReq
     );
 

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/inner/ServiceFileUploadSettingDTO.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/inner/ServiceFileUploadSettingDTO.java
@@ -41,7 +41,7 @@ import java.util.List;
 @Data
 public class ServiceFileUploadSettingDTO {
     @ApiModelProperty("数量")
-    private Long amount;
+    private Float amount;
     @ApiModelProperty("单位")
     private String unit;
     @ApiModelProperty("限制模式，0:禁止范围，1：允许范围")

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/AccountCreateUpdateReq.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/AccountCreateUpdateReq.java
@@ -29,9 +29,8 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import lombok.ToString;
+import org.hibernate.validator.constraints.Range;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
 import java.util.List;
 
 @Data
@@ -82,8 +81,7 @@ public class AccountCreateUpdateReq {
     private String password;
 
     @ApiModelProperty(value = "DB端口,创建/更新DB账号的时候必传")
-    @Min(value = 0, message = "{validation.constraints.InvalidPort.message}")
-    @Max(value = 65536, message = "{validation.constraints.InvalidPort.message}")
+    @Range(min = 0, max = 65536, message = "{validation.constraints.InvalidPort.message}")
     private Integer dbPort;
 
     @ApiModelProperty(value = "DB账号关联的系统账号,创建/更新DB账号的时候必传")

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/AccountCreateUpdateReq.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/AccountCreateUpdateReq.java
@@ -30,6 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import lombok.ToString;
 
+import javax.validation.constraints.Positive;
 import java.util.List;
 
 @Data
@@ -37,7 +38,7 @@ import java.util.List;
 @ToString(exclude = {"password", "dbPassword"})
 public class AccountCreateUpdateReq {
 
-    @ApiModelProperty(value = "ID,更新账号的时候需要传入，新建账号不需要", required = false)
+    @ApiModelProperty(value = "ID,更新账号的时候需要传入，新建账号不需要")
     private Long id;
     /**
      * 帐号名称
@@ -45,47 +46,48 @@ public class AccountCreateUpdateReq {
     @ApiModelProperty(value = "帐号名称", required = true)
     private String account;
 
-    @ApiModelProperty(value = "账号类型，新建的时候需要传入；1-Linux，2-Windows，9-Mysql，10-Oracle，11-DB2", required = false)
+    @ApiModelProperty(value = "账号类型，新建的时候需要传入；1-Linux，2-Windows，9-Mysql，10-Oracle，11-DB2")
     private Integer type;
 
-    @ApiModelProperty(value = "账号用途，新建的时候需要传入；1-系统账号，2-数据库账号", required = false)
+    @ApiModelProperty(value = "账号用途，新建的时候需要传入；1-系统账号，2-数据库账号")
     private Integer category;
 
     /**
      * 所属用户
      */
-    @ApiModelProperty(value = "所属用户", required = false)
+    @ApiModelProperty(value = "所属用户")
     private List<String> grantees;
 
     /**
      * 备注
      */
-    @ApiModelProperty(value = "备注", required = false)
+    @ApiModelProperty(value = "备注")
     private String remark;
 
     /**
      * 系统类型，Linux / Windows
      */
-    @ApiModelProperty(value = "系统类型", required = false)
+    @ApiModelProperty(value = "系统类型")
     private String os;
 
     /**
      * 别名，当重名时会让用户填写，不允许修改，并且最后会与os合并在一起生成一个标识性的
      */
-    @ApiModelProperty(value = "别名", required = false)
+    @ApiModelProperty(value = "别名")
     private String alias;
 
-    @ApiModelProperty(value = "系统账号的密码(Windows)", required = false)
+    @ApiModelProperty(value = "系统账号的密码(Windows)")
     @SkipLogFields
     private String password;
 
-    @ApiModelProperty(value = "DB端口,创建/更新DB账号的时候必传", required = false)
+    @ApiModelProperty(value = "DB端口,创建/更新DB账号的时候必传")
+    @Positive(message = "{validation.constraints.InvalidPort.message}")
     private Integer dbPort;
 
-    @ApiModelProperty(value = "DB账号关联的系统账号,创建/更新DB账号的时候必传", required = false)
+    @ApiModelProperty(value = "DB账号关联的系统账号,创建/更新DB账号的时候必传")
     private Long dbSystemAccountId;
 
-    @ApiModelProperty(value = "DB账号的密码,创建/更新DB账号的时候必传", required = false)
+    @ApiModelProperty(value = "DB账号的密码,创建/更新DB账号的时候必传")
     @SkipLogFields
     private String dbPassword;
 }

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/AccountCreateUpdateReq.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/AccountCreateUpdateReq.java
@@ -30,7 +30,8 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import lombok.ToString;
 
-import javax.validation.constraints.Positive;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import java.util.List;
 
 @Data
@@ -81,7 +82,8 @@ public class AccountCreateUpdateReq {
     private String password;
 
     @ApiModelProperty(value = "DB端口,创建/更新DB账号的时候必传")
-    @Positive(message = "{validation.constraints.InvalidPort.message}")
+    @Min(value = 0, message = "{validation.constraints.InvalidPort.message}")
+    @Max(value = 65536, message = "{validation.constraints.InvalidPort.message}")
     private Integer dbPort;
 
     @ApiModelProperty(value = "DB账号关联的系统账号,创建/更新DB账号的时候必传")

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/globalsetting/FileUploadSettingReq.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/globalsetting/FileUploadSettingReq.java
@@ -55,12 +55,12 @@ public class FileUploadSettingReq {
     private StorageUnitEnum unit;
 
     @ApiModelProperty("限制模式，0:禁止范围，1：允许范围，-1：不限制")
-    @CheckEnum(enumClass = RestrictModeEnum.class, enumMethod = "isValid", message = "{validation.constraints" +
-        ".InvalidUploadFileRestrictMode.message}")
+    @CheckEnum(enumClass = RestrictModeEnum.class, enumMethod = "isValid",
+        message = "{validation.constraints.InvalidUploadFileRestrictMode.message}")
     private Integer restrictMode;
 
     @ApiModelProperty("后缀列表")
-    private List<@Pattern(regexp = "^\\.[A-Za-z0-9_-]{1,24}$", message = "{validation.constraints" +
-        ".InvalidUploadFileSuffix.message}") String> suffixList;
+    private List<@Pattern(regexp = "^\\.[A-Za-z0-9_-]{1,24}$",
+        message = "{validation.constraints.InvalidUploadFileSuffix.message}") String> suffixList;
 
 }

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/globalsetting/FileUploadSettingReq.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/globalsetting/FileUploadSettingReq.java
@@ -34,6 +34,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Positive;
 import java.util.List;
 
 /**
@@ -47,13 +48,19 @@ import java.util.List;
 @ApiModel("文件上传参数")
 public class FileUploadSettingReq {
     @ApiModelProperty("数量")
-    private Long amount;
+    @Positive(message = "{validation.constraints.InvalidFileUploadSettingAmount.message}")
+    private Float amount;
+
     @ApiModelProperty("单位:可选B/KB/MB/GB/TB/PB")
     private StorageUnitEnum unit;
+
     @ApiModelProperty("限制模式，0:禁止范围，1：允许范围，-1：不限制")
-    @CheckEnum(enumClass = RestrictModeEnum.class, enumMethod = "isValid", message = "{validation.constraints.InvalidUploadFileRestrictMode.message}")
+    @CheckEnum(enumClass = RestrictModeEnum.class, enumMethod = "isValid", message = "{validation.constraints" +
+        ".InvalidUploadFileRestrictMode.message}")
     private Integer restrictMode;
+
     @ApiModelProperty("后缀列表")
-    private List<@Pattern(regexp = "^\\.[A-Za-z0-9_-]{1,24}$", message = "{validation.constraints.InvalidUploadFileSuffix.message}") String> suffixList;
+    private List<@Pattern(regexp = "^\\.[A-Za-z0-9_-]{1,24}$", message = "{validation.constraints" +
+        ".InvalidUploadFileSuffix.message}") String> suffixList;
 
 }

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/vo/globalsetting/FileUploadSettingVO.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/vo/globalsetting/FileUploadSettingVO.java
@@ -41,7 +41,7 @@ import java.util.List;
 @Data
 public class FileUploadSettingVO {
     @ApiModelProperty("数量")
-    private Long amount;
+    private Float amount;
     @ApiModelProperty("单位")
     private String unit;
     @ApiModelProperty("限制模式，0:禁止范围，1：允许范围")

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/GlobalSettingsServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/GlobalSettingsServiceImpl.java
@@ -393,18 +393,18 @@ public class GlobalSettingsServiceImpl implements GlobalSettingsService {
         }
     }
 
-    private Pair<Long, String> parseFileSize(String str) {
+    private Pair<Float, String> parseFileSize(String str) {
         Matcher matcher = PATTERN.matcher(str);
         if (!matcher.matches()) {
             return null;
         }
-        long amount = Long.parseLong(matcher.group(1));
+        float amount = Float.parseFloat(matcher.group(1));
         String unit = matcher.group(2);
         return Pair.of(amount, unit);
     }
 
     private FileUploadSettingVO getFileUploadSettingsFromStr(String str) {
-        Pair<Long, String> configedValue = parseFileSize(str);
+        Pair<Float, String> configedValue = parseFileSize(str);
         if (configedValue == null) return null;
         return new FileUploadSettingVO(configedValue.getLeft(), configedValue.getRight(), null, null);
     }
@@ -416,7 +416,7 @@ public class GlobalSettingsServiceImpl implements GlobalSettingsService {
 
     @Override
     public Boolean saveFileUploadSettings(String username, FileUploadSettingReq req) {
-        Long uploadMaxSize = req.getAmount();
+        Float uploadMaxSize = req.getAmount();
         StorageUnitEnum unit = req.getUnit();
         Integer restrictMode = req.getRestrictMode();
         List<String> suffixList = req.getSuffixList();
@@ -424,7 +424,7 @@ public class GlobalSettingsServiceImpl implements GlobalSettingsService {
             unit = StorageUnitEnum.B;
         }
         if (uploadMaxSize <= 0) {
-            uploadMaxSize = 5L;
+            uploadMaxSize = 5.0f;
             unit = StorageUnitEnum.GB;
         }
         if (restrictMode == null) {

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/GlobalSettingsServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/GlobalSettingsServiceImpl.java
@@ -112,7 +112,7 @@ import java.util.stream.Collectors;
 @Service
 public class GlobalSettingsServiceImpl implements GlobalSettingsService {
 
-    private static final Pattern PATTERN = Pattern.compile("^([+\\-]?\\d+)([a-zA-Z]{0,2})$");
+    private static final Pattern PATTERN = Pattern.compile("^([.0-9]+)([a-zA-Z]{0,2})$");
     private static final String STRING_TPL_KEY_CURRENT_VERSION = "current_ver";
     private static final String STRING_TPL_KEY_CURRENT_YEAR = "current_year";
     private final DSLContext dslContext;


### PR DESCRIPTION
1. [bugfix: 本地文件上传大小限制可以输入负数](https://github.com/Tencent/bk-job/commit/865add2a9acea6200450036eebc207c755b6aefb) https://github.com/Tencent/bk-job/issues/1445
2. [bugfix: 数据库账号的端口可以输入负数](https://github.com/Tencent/bk-job/commit/8f02a13a96c6740ae96149b7341e3d0e4bd9f050) https://github.com/Tencent/bk-job/issues/1446