### PR TITLE
bugfix: 高危语句检测存在一个正则失败的规则会导致所有该种类所有规则不生效 #1440

### DIFF
--- a/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages.properties
@@ -28,6 +28,7 @@ validation.constraints.InvalidJobTimeout_empty.message=作业超时时间不能�
 validation.constraints.InvalidJobTimeout_outOfRange.message=作业超时时间必须在{min}-{max}之间
 validation.constraints.InvalidJobHighRiskGrammarRegex_empty.message=语法检测表达式不能为空
 validation.constraints.InvalidJobHighRiskGrammarRegex_outOfLength.message=语法检测表达式不能超过{max}个字符
+validation.constraints.InvalidJobHighRiskGrammarRegex_wrongExpr.message=语法检测表达式错误
 validation.constraints.ScriptTypeList_empty.message=脚本类型不能为空
 validation.constraints.InvalidHighRiskGrammarHandleAction.message=非法的处理动作
 validation.constraints.InvalidHighRiskRegularStatus.message=非法的规则启停状态

--- a/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_en.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_en.properties
@@ -28,6 +28,7 @@ validation.constraints.InvalidJobTimeout_empty.message=Job timeout cannot be emp
 validation.constraints.InvalidJobTimeout_outOfRange.message=Job timeout must be between {min} and {max}
 validation.constraints.InvalidJobHighRiskGrammarRegex_empty.message=High-risk grammar regex can not be empty
 validation.constraints.InvalidJobHighRiskGrammarRegex_outOfLength.message=High-risk grammar regex can not exceed  {max} characters
+validation.constraints.InvalidJobHighRiskGrammarRegex_wrongExpr.message=Wrong high-risk grammar regex
 validation.constraints.ScriptTypeList_empty.message=Script type cannot be empty
 validation.constraints.InvalidHighRiskGrammarHandleAction.message=Invalid handle action
 validation.constraints.InvalidHighRiskRegularStatus.message=Invalid regular status

--- a/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_en_US.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_en_US.properties
@@ -28,6 +28,7 @@ validation.constraints.InvalidJobTimeout_empty.message=Job timeout cannot be emp
 validation.constraints.InvalidJobTimeout_outOfRange.message=Job timeout must be between {min} and {max}
 validation.constraints.InvalidJobHighRiskGrammarRegex_empty.message=High-risk grammar regex can not be empty
 validation.constraints.InvalidJobHighRiskGrammarRegex_outOfLength.message=High-risk grammar regex can not exceed {max} characters
+validation.constraints.InvalidJobHighRiskGrammarRegex_wrongExpr.message=Wrong high-risk grammar regex
 validation.constraints.ScriptTypeList_empty.message=Script type cannot be empty
 validation.constraints.InvalidHighRiskGrammarHandleAction.message=Invalid handle action
 validation.constraints.InvalidHighRiskRegularStatus.message=Invalid regular status

--- a/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_zh.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_zh.properties
@@ -28,6 +28,7 @@ validation.constraints.InvalidJobTimeout_empty.message=作业超时时间不能�
 validation.constraints.InvalidJobTimeout_outOfRange.message=作业超时时间必须在{min}-{max}之间
 validation.constraints.InvalidJobHighRiskGrammarRegex_empty.message=语法检测表达式不能为空
 validation.constraints.InvalidJobHighRiskGrammarRegex_outOfLength.message=语法检测表达式不能超过{max}个字符
+validation.constraints.InvalidJobHighRiskGrammarRegex_wrongExpr.message=语法检测表达式错误
 validation.constraints.ScriptTypeList_empty.message=脚本类型不能为空
 validation.constraints.InvalidHighRiskGrammarHandleAction.message=非法的处理动作
 validation.constraints.InvalidHighRiskRegularStatus.message=非法的规则启停状态

--- a/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_zh_CN.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/validation/ValidationMessages_zh_CN.properties
@@ -28,6 +28,7 @@ validation.constraints.InvalidJobTimeout_empty.message=作业超时时间不能�
 validation.constraints.InvalidJobTimeout_outOfRange.message=作业超时时间必须在{min}-{max}之间
 validation.constraints.InvalidJobHighRiskGrammarRegex_empty.message=语法检测表达式不能为空
 validation.constraints.InvalidJobHighRiskGrammarRegex_outOfLength.message=语法检测表达式不能超过{max}个字符
+validation.constraints.InvalidJobHighRiskGrammarRegex_wrongExpr.message=语法检测表达式错误
 validation.constraints.ScriptTypeList_empty.message=脚本类型不能为空
 validation.constraints.InvalidHighRiskGrammarHandleAction.message=非法的处理动作
 validation.constraints.InvalidHighRiskRegularStatus.message=非法的规则启停状态

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/validation/ValidRegexPattern.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/validation/ValidRegexPattern.java
@@ -1,0 +1,75 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.validation;
+
+import org.apache.commons.lang3.StringUtils;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.regex.Pattern;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * spring validation java 正则表达式合法校验
+ */
+@Target({FIELD, METHOD, PARAMETER, ANNOTATION_TYPE, TYPE_USE})
+@Constraint(validatedBy = ValidRegexPattern.Validator.class)
+@Documented
+@Retention(RUNTIME)
+public @interface ValidRegexPattern {
+
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    class Validator implements ConstraintValidator<ValidRegexPattern, String> {
+
+        @Override
+        public boolean isValid(String value, ConstraintValidatorContext constraintValidatorContext) {
+            if (StringUtils.isEmpty(value)) {
+                return false;
+            }
+            try {
+                Pattern.compile(value);
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+    }
+}

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/DangerousScriptCheckServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/DangerousScriptCheckServiceImpl.java
@@ -74,14 +74,9 @@ public class DangerousScriptCheckServiceImpl implements DangerousScriptCheckServ
 
     @Override
     public List<ServiceScriptCheckResultItemDTO> check(ScriptTypeEnum scriptType, String content) {
-        try {
-            InternalResponse<List<ServiceScriptCheckResultItemDTO>> response =
-                scriptCheckResourceClient.check(new ServiceCheckScriptRequest(content, scriptType.getValue()));
-            return response.isSuccess() ? response.getData() : Collections.emptyList();
-        } catch (Throwable e) {
-            // 服务降级，返回空的检查结果
-            return Collections.emptyList();
-        }
+        InternalResponse<List<ServiceScriptCheckResultItemDTO>> response =
+            scriptCheckResourceClient.check(new ServiceCheckScriptRequest(content, scriptType.getValue()));
+        return response.isSuccess() ? response.getData() : Collections.emptyList();
     }
 
     @Override

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/TaskExecuteServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/TaskExecuteServiceImpl.java
@@ -42,6 +42,7 @@ import com.tencent.bk.job.common.iam.model.AuthResult;
 import com.tencent.bk.job.common.model.InternalResponse;
 import com.tencent.bk.job.common.model.dto.AppResourceScope;
 import com.tencent.bk.job.common.model.dto.IpDTO;
+import com.tencent.bk.job.common.trace.executors.TraceableExecutorService;
 import com.tencent.bk.job.common.util.ArrayUtil;
 import com.tencent.bk.job.common.util.date.DateUtils;
 import com.tencent.bk.job.common.util.json.JsonUtils;
@@ -51,7 +52,6 @@ import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
 import com.tencent.bk.job.execute.common.constants.StepExecuteTypeEnum;
 import com.tencent.bk.job.execute.common.constants.TaskStartupModeEnum;
 import com.tencent.bk.job.execute.common.constants.TaskTypeEnum;
-import com.tencent.bk.job.common.trace.executors.TraceableExecutorService;
 import com.tencent.bk.job.execute.config.JobExecuteConfig;
 import com.tencent.bk.job.execute.constants.ScriptSourceEnum;
 import com.tencent.bk.job.execute.constants.StepOperationEnum;
@@ -456,6 +456,7 @@ public class TaskExecuteServiceImpl implements TaskExecuteService {
             String checkResultSummary =
                 dangerousScriptCheckService.summaryDangerousScriptCheckResult(stepInstance.getName(), checkResultItems);
             if (StringUtils.isNotBlank(checkResultSummary)) {
+                log.info("Script match dangerous rule, checkResult: {}", checkResultItems);
                 dangerousScriptCheckService.saveDangerousRecord(taskInstance, stepInstance, checkResultItems);
                 if (dangerousScriptCheckService.shouldIntercept(checkResultItems)) {
                     throw new AbortedException(ErrorCode.DANGEROUS_SCRIPT_FORBIDDEN_EXECUTION,

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/inner/request/ServiceCheckScriptRequest.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/inner/request/ServiceCheckScriptRequest.java
@@ -24,10 +24,14 @@
 
 package com.tencent.bk.job.manage.model.inner.request;
 
+import com.tencent.bk.job.common.validation.CheckEnum;
+import com.tencent.bk.job.manage.common.consts.script.ScriptTypeEnum;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
 
 /**
  * 检查脚本集请求
@@ -40,6 +44,7 @@ public class ServiceCheckScriptRequest {
      * 脚本内容
      */
     @ApiModelProperty("脚本内容")
+    @NotBlank
     private String scriptContent;
     /**
      * 脚本类型
@@ -47,6 +52,7 @@ public class ServiceCheckScriptRequest {
      * @see com.tencent.bk.job.manage.common.consts.script.ScriptTypeEnum
      */
     @ApiModelProperty("脚本类型")
+    @CheckEnum(enumClass = ScriptTypeEnum.class, enumMethod = "isValid")
     private Integer scriptType;
 
     public ServiceCheckScriptRequest(String scriptContent, Integer scriptType) {

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/globalsetting/AddOrUpdateDangerousRuleReq.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/globalsetting/AddOrUpdateDangerousRuleReq.java
@@ -26,6 +26,7 @@ package com.tencent.bk.job.manage.model.web.request.globalsetting;
 
 import com.tencent.bk.job.common.validation.CheckEnum;
 import com.tencent.bk.job.common.validation.Update;
+import com.tencent.bk.job.common.validation.ValidRegexPattern;
 import com.tencent.bk.job.manage.common.consts.rule.HighRiskGrammarActionEnum;
 import com.tencent.bk.job.manage.common.consts.rule.HighRiskGrammarRuleStatusEnum;
 import com.tencent.bk.job.manage.validation.provider.DangerousRuleGroupSequenceProvider;
@@ -52,6 +53,7 @@ public class AddOrUpdateDangerousRuleReq {
     @ApiModelProperty("表达式")
     @NotEmpty(message = "{validation.constraints.InvalidJobHighRiskGrammarRegex_empty.message}")
     @Length(max = 250, message = "{validation.constraints.InvalidJobHighRiskGrammarRegex_outOfLength.message}")
+    @ValidRegexPattern(message = "{validation.constraints.InvalidJobHighRiskGrammarRegex_wrongExpr.message}")
     private String expression;
     @ApiModelProperty("脚本类型：SHELL(1), BAT(2), PERL(3), PYTHON(4),POWERSHELL(5), SQL(6)")
     @NotEmpty(message = "{validation.constraints.ScriptTypeList_empty.message}")

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/inner/impl/ServiceCheckScriptResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/inner/impl/ServiceCheckScriptResourceImpl.java
@@ -32,11 +32,9 @@ import com.tencent.bk.job.manage.model.inner.ServiceScriptCheckResultItemDTO;
 import com.tencent.bk.job.manage.model.inner.request.ServiceCheckScriptRequest;
 import com.tencent.bk.job.manage.service.ScriptCheckService;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -52,16 +50,8 @@ public class ServiceCheckScriptResourceImpl implements ServiceCheckScriptResourc
 
     @Override
     public InternalResponse<List<ServiceScriptCheckResultItemDTO>> check(ServiceCheckScriptRequest checkScriptRequest) {
-        if (StringUtils.isEmpty(checkScriptRequest.getScriptContent())) {
-            return InternalResponse.buildSuccessResp(Collections.emptyList());
-        }
-        ScriptTypeEnum scriptType = checkScriptRequest.getScriptType() == null ?
-            null : ScriptTypeEnum.valueOf(checkScriptRequest.getScriptType());
-        if (scriptType == null) {
-            return InternalResponse.buildSuccessResp(Collections.emptyList());
-        }
         List<ScriptCheckResultItemDTO> checkResultItems = scriptCheckService.checkScriptWithDangerousRule(
-            scriptType, checkScriptRequest.getScriptContent());
+            ScriptTypeEnum.valueOf(checkScriptRequest.getScriptType()), checkScriptRequest.getScriptContent());
         return InternalResponse.buildSuccessResp(checkResultItems.stream()
             .map(ScriptCheckResultItemDTO::toServiceScriptCheckResultDTO)
             .collect(Collectors.toList()));

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebDangerousRuleResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebDangerousRuleResourceImpl.java
@@ -24,9 +24,7 @@
 
 package com.tencent.bk.job.manage.api.web.impl;
 
-import com.tencent.bk.job.common.exception.InvalidParamException;
 import com.tencent.bk.job.common.model.Response;
-import com.tencent.bk.job.common.model.ValidateResult;
 import com.tencent.bk.job.manage.api.web.WebDangerousRuleResource;
 import com.tencent.bk.job.manage.model.web.request.globalsetting.AddOrUpdateDangerousRuleReq;
 import com.tencent.bk.job.manage.model.web.request.globalsetting.MoveDangerousRuleReq;
@@ -55,20 +53,7 @@ public class WebDangerousRuleResourceImpl implements WebDangerousRuleResource {
 
     @Override
     public Response<Boolean> addOrUpdateDangerousRule(String username, AddOrUpdateDangerousRuleReq req) {
-        ValidateResult validateResult = checkAddOrUpdateDangerousRuleReq(req);
-        if (!validateResult.isPass()) {
-            throw new InvalidParamException(validateResult);
-        }
         return Response.buildSuccessResp(dangerousRuleService.addOrUpdateDangerousRule(username, req));
-    }
-
-    private ValidateResult checkAddOrUpdateDangerousRuleReq(AddOrUpdateDangerousRuleReq req) {
-//        if (req.getId() == null || req.getId() == -1) {
-//            // 新增
-//        } else {
-//
-//        }
-        return ValidateResult.pass();
     }
 
     @Override

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/ScriptCheckServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/ScriptCheckServiceImpl.java
@@ -107,12 +107,11 @@ public class ScriptCheckServiceImpl implements ScriptCheckService {
             checkResultList.sort(Comparator.comparingInt(ScriptCheckResultItemDTO::getLine));
 
         } catch (Exception e) {
-            // 脚本检查非强制，如果检查过程中抛出异常不应该影响业务的使用
             String errorMsg = MessageFormatter.format(
                 "Check script caught exception! scriptType: {}, content: {}",
                 scriptType, content).getMessage();
             log.error(errorMsg, e);
-            return Collections.emptyList();
+            throw new InternalException(e, ErrorCode.INTERNAL_ERROR);
         }
         return checkResultList;
     }


### PR DESCRIPTION
1. 高危表达式校验
2. 取消服务降级，如果执行过程中抛出异常，那么直接报错拦截。原先的catch住所有异常的方式存在漏洞