### PR TITLE
bugfix: 数据库账号的端口/本地文件上传大小限制可以输入负数 #1446 #1445

### DIFF
--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/AccountCreateUpdateReq.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/AccountCreateUpdateReq.java
@@ -31,6 +31,7 @@ import lombok.Data;
 import lombok.ToString;
 import org.hibernate.validator.constraints.Range;
 
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Data
@@ -81,6 +82,7 @@ public class AccountCreateUpdateReq {
     private String password;
 
     @ApiModelProperty(value = "DB端口,创建/更新DB账号的时候必传")
+    @NotNull(message = "{validation.constraints.InvalidPort.message}")
     @Range(min = 0, max = 65535, message = "{validation.constraints.InvalidPort.message}")
     private Integer dbPort;
 

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/globalsetting/FileUploadSettingReq.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/globalsetting/FileUploadSettingReq.java
@@ -33,6 +33,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Positive;
 import java.util.List;
@@ -48,6 +49,7 @@ import java.util.List;
 @ApiModel("文件上传参数")
 public class FileUploadSettingReq {
     @ApiModelProperty("数量")
+    @NotNull(message = "{validation.constraints.InvalidFileUploadSettingAmount.message}")
     @Positive(message = "{validation.constraints.InvalidFileUploadSettingAmount.message}")
     private Float amount;
 


### PR DESCRIPTION
bugfix: 本地文件上传大小限制可以输入负数 #1445
bugfix: 数据库账号的端口可以输入负数 #1446