### PR TITLE
feature: job支持IPv6主机执行 #1056

### DIFF
--- a/src/backend/job-logsvr/api-job-logsvr/src/main/java/com/tencent/bk/job/logsvr/api/ServiceLogResource.java
+++ b/src/backend/job-logsvr/api-job-logsvr/src/main/java/com/tencent/bk/job/logsvr/api/ServiceLogResource.java
@@ -33,6 +33,7 @@ import com.tencent.bk.job.logsvr.model.service.ServiceFileLogQueryRequest;
 import com.tencent.bk.job.logsvr.model.service.ServiceFileTaskLogDTO;
 import com.tencent.bk.job.logsvr.model.service.ServiceHostLogDTO;
 import com.tencent.bk.job.logsvr.model.service.ServiceHostLogsDTO;
+import com.tencent.bk.job.logsvr.model.service.ServiceSaveLogRequest;
 import com.tencent.bk.job.logsvr.model.service.ServiceScriptLogQueryRequest;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -55,6 +56,19 @@ import java.util.List;
 @RestController
 @InternalAPI
 public interface ServiceLogResource {
+
+    /**
+     * 保存执行日志
+     * tmp: ipv6版本发布完成后删除
+     * @param request 保存日志请求
+     */
+    @ApiOperation("保存执行日志")
+    @PostMapping
+    @Deprecated
+    InternalResponse<?> saveLog(
+        @ApiParam("保存日志请求报文")
+        @RequestBody ServiceSaveLogRequest request
+    );
 
     /**
      * 批量保存执行日志

--- a/src/backend/job-logsvr/service-job-logsvr/src/main/java/com/tencent/bk/job/logsvr/api/service/impl/ServiceLogResourceImpl.java
+++ b/src/backend/job-logsvr/service-job-logsvr/src/main/java/com/tencent/bk/job/logsvr/api/service/impl/ServiceLogResourceImpl.java
@@ -39,6 +39,7 @@ import com.tencent.bk.job.logsvr.model.service.ServiceFileLogQueryRequest;
 import com.tencent.bk.job.logsvr.model.service.ServiceFileTaskLogDTO;
 import com.tencent.bk.job.logsvr.model.service.ServiceHostLogDTO;
 import com.tencent.bk.job.logsvr.model.service.ServiceHostLogsDTO;
+import com.tencent.bk.job.logsvr.model.service.ServiceSaveLogRequest;
 import com.tencent.bk.job.logsvr.model.service.ServiceScriptLogDTO;
 import com.tencent.bk.job.logsvr.model.service.ServiceScriptLogQueryRequest;
 import com.tencent.bk.job.logsvr.service.LogService;
@@ -63,6 +64,15 @@ public class ServiceLogResourceImpl implements ServiceLogResource {
     @Autowired
     public ServiceLogResourceImpl(LogService logService) {
         this.logService = logService;
+    }
+
+    @Override
+    public InternalResponse<?> saveLog(ServiceSaveLogRequest request) {
+        TaskHostLog taskHostLog = convertToTaskHostLog(request.getLogType(), request.getJobCreateDate(),
+            request.getStepInstanceId(), request.getExecuteCount(), request.getBatch(), request.getHostId(),
+            request.getIp(), null, request.getScriptLog(), request.getFileTaskLogs());
+        logService.saveLog(taskHostLog);
+        return InternalResponse.buildSuccessResp(null);
     }
 
     @Override

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebTaskPlanResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebTaskPlanResourceImpl.java
@@ -373,14 +373,14 @@ public class WebTaskPlanResourceImpl implements WebTaskPlanResource {
         boolean isMissingHostId = false;
         for (TaskStepVO step : taskPlan.getStepList()) {
             if (step.getScriptStepInfo() != null) {
-                isMissingHostId = isMissingHostId || fillHostId(step.getScriptStepInfo().getExecuteTarget());
+                isMissingHostId = fillHostId(step.getScriptStepInfo().getExecuteTarget()) || isMissingHostId;
             } else if (step.getFileStepInfo() != null) {
                 TaskFileStepVO fileStep = step.getFileStepInfo();
-                fillHostId(fileStep.getFileDestination().getServer());
+                isMissingHostId = fillHostId(fileStep.getFileDestination().getServer()) || isMissingHostId;
                 if (CollectionUtils.isNotEmpty(fileStep.getFileSourceList())) {
                     for (TaskFileSourceInfoVO source : fileStep.getFileSourceList()) {
                         if (source.getHost() != null) {
-                            isMissingHostId = isMissingHostId || fillHostId(source.getHost());
+                            isMissingHostId = fillHostId(source.getHost()) || isMissingHostId;
                         }
                     }
                 }
@@ -389,7 +389,7 @@ public class WebTaskPlanResourceImpl implements WebTaskPlanResource {
         if (CollectionUtils.isNotEmpty(taskPlan.getVariableList())) {
             for (TaskVariableVO var : taskPlan.getVariableList()) {
                 if (var.getDefaultTargetValue() != null) {
-                    isMissingHostId = isMissingHostId || fillHostId(var.getDefaultTargetValue());
+                    isMissingHostId = fillHostId(var.getDefaultTargetValue()) || isMissingHostId;
                 }
             }
         }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebTaskPlanResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebTaskPlanResourceImpl.java
@@ -388,8 +388,8 @@ public class WebTaskPlanResourceImpl implements WebTaskPlanResource {
         }
         if (CollectionUtils.isNotEmpty(taskPlan.getVariableList())) {
             for (TaskVariableVO var : taskPlan.getVariableList()) {
-                if (var.getTargetValue() != null) {
-                    isMissingHostId = isMissingHostId || fillHostId(var.getTargetValue());
+                if (var.getDefaultTargetValue() != null) {
+                    isMissingHostId = isMissingHostId || fillHostId(var.getDefaultTargetValue());
                 }
             }
         }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/plan/impl/TaskPlanServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/plan/impl/TaskPlanServiceImpl.java
@@ -93,8 +93,7 @@ public class TaskPlanServiceImpl implements TaskPlanService {
         TaskPlanDAO taskPlanDAO,
         @Qualifier("TaskPlanStepServiceImpl") AbstractTaskStepService taskPlanStepService,
         @Qualifier("TaskPlanVariableServiceImpl") AbstractTaskVariableService taskPlanVariableService,
-        MessageI18nService i18nService, CronJobService cronJobService
-    ) {
+        MessageI18nService i18nService, CronJobService cronJobService) {
         this.taskPlanDAO = taskPlanDAO;
         this.taskPlanStepService = taskPlanStepService;
         this.taskPlanVariableService = taskPlanVariableService;


### PR DESCRIPTION
1. 兼容GSE 1.0 的文件协议V1版本
2. 发布兼容: 恢复被删除的执行日志写入API, 发布完成后再删除
3. 发布兼容: 通过Job页面查询执行方案详情，如果没有hostId,那么会根据云区域id+ip补充对应主机的hostId（因为前段不兼容没有hostId的情况)