### PR TITLE
bugfix: [ipv6] 执行详情-分组-复制主机的ipv6地址失败 #1523

### DIFF
--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/BaseHttpHelper.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/BaseHttpHelper.java
@@ -73,7 +73,7 @@ public class BaseHttpHelper implements HttpHelper {
             throw new InternalException(e, ErrorCode.API_ERROR);
         } finally {
             if (log.isDebugEnabled()) {
-                log.debug("getRawResp,url={},headers={}", url, header);
+                log.debug("getRawResp,url={}", url);
             }
         }
     }
@@ -101,10 +101,9 @@ public class BaseHttpHelper implements HttpHelper {
             get.releaseConnection();
             if (log.isDebugEnabled()) {
                 log.debug(
-                    "get:keepAlive={},url={},headers={},httpStatusCode={},respStr={}",
+                    "get:keepAlive={},url={},httpStatusCode={},respStr={}",
                     keepAlive,
                     url,
-                    header,
                     httpStatusCode,
                     respStr
                 );
@@ -130,12 +129,11 @@ public class BaseHttpHelper implements HttpHelper {
                     respStr = new String(EntityUtils.toByteArray(entity), CHARSET);
                 }
                 log.warn(
-                    "Post request fail, httpStatusCode={}, errorReason={}, body={}, url={}, headers={}",
+                    "Post request fail, httpStatusCode={}, errorReason={}, body={}, url={}",
                     httpStatusCode,
                     message,
                     respStr,
-                    url,
-                    headers
+                    url
                 );
                 throw new InternalException(message, ErrorCode.API_ERROR);
             }
@@ -190,9 +188,8 @@ public class BaseHttpHelper implements HttpHelper {
             put.releaseConnection();
             if (log.isDebugEnabled()) {
                 log.debug(
-                    "put:url={},headers={},requestEntity={},httpStatusCode={},respStr={}",
+                    "put:url={},requestEntity={},httpStatusCode={},respStr={}",
                     url,
-                    headers,
                     requestEntity,
                     httpStatusCode,
                     respStr
@@ -240,9 +237,8 @@ public class BaseHttpHelper implements HttpHelper {
             delete.releaseConnection();
             if (log.isDebugEnabled()) {
                 log.debug(
-                    "delete:url={},headers={},body={},httpStatusCode={},respStr={}",
+                    "delete:url={},body={},httpStatusCode={},respStr={}",
                     url,
-                    headers,
                     content,
                     httpStatusCode,
                     respStr

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/BaseHttpHelper.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/BaseHttpHelper.java
@@ -73,7 +73,7 @@ public class BaseHttpHelper implements HttpHelper {
             throw new InternalException(e, ErrorCode.API_ERROR);
         } finally {
             if (log.isDebugEnabled()) {
-                log.debug("getRawResp,url={}", url);
+                log.debug("getRawResp,url={},headers={}", url, header);
             }
         }
     }
@@ -101,7 +101,7 @@ public class BaseHttpHelper implements HttpHelper {
             get.releaseConnection();
             if (log.isDebugEnabled()) {
                 log.debug(
-                    "get:keepAlive={},url={},httpStatusCode={},respStr={}",
+                    "get:keepAlive={},url={},headers={},httpStatusCode={},respStr={}",
                     keepAlive,
                     url,
                     httpStatusCode,
@@ -188,8 +188,9 @@ public class BaseHttpHelper implements HttpHelper {
             put.releaseConnection();
             if (log.isDebugEnabled()) {
                 log.debug(
-                    "put:url={},requestEntity={},httpStatusCode={},respStr={}",
+                    "put:url={},headers={},requestEntity={},httpStatusCode={},respStr={}",
                     url,
+                    headers,
                     requestEntity,
                     httpStatusCode,
                     respStr
@@ -237,8 +238,9 @@ public class BaseHttpHelper implements HttpHelper {
             delete.releaseConnection();
             if (log.isDebugEnabled()) {
                 log.debug(
-                    "delete:url={},body={},httpStatusCode={},respStr={}",
+                    "delete:url={},headers={},body={},httpStatusCode={},respStr={}",
                     url,
+                    headers,
                     content,
                     httpStatusCode,
                     respStr

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/ScriptAgentTaskResult.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/ScriptAgentTaskResult.java
@@ -1,6 +1,7 @@
 package com.tencent.bk.job.common.gse.v2.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.tencent.bk.job.common.util.json.SkipLogFields;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -71,7 +72,19 @@ public class ScriptAgentTaskResult {
      * 脚本输出日志
      */
     @JsonProperty("screen")
+    @SkipLogFields
     private String screen;
+
+    /**
+     * 非协议内容，仅用于日志输出
+     */
+    private long contentLength;
+
+
+    public void setScreen(String screen) {
+        this.screen = screen;
+        this.contentLength = StringUtils.isEmpty(screen) ? 0 : screen.length();
+    }
 
     @Override
     public String toString() {
@@ -85,7 +98,7 @@ public class ScriptAgentTaskResult {
             .add("endTime=" + endTime)
             .add("exitCode=" + exitCode)
             .add("tag='" + tag + "'")
-            .add("contentLength=" + (StringUtils.isEmpty(screen) ? 0 : screen.length()))
+            .add("contentLength=" + contentLength)
             .toString();
     }
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/model/AgentTaskDetailDTO.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/model/AgentTaskDetailDTO.java
@@ -69,6 +69,7 @@ public class AgentTaskDetailDTO extends AgentTaskDTO {
         HostDTO host = new HostDTO();
         host.setHostId(getHostId());
         host.setIp(getIp());
+        host.setIpv6(getIpv6());
         host.setBkCloudId(getBkCloudId());
         host.setBkCloudName(getBkCloudName());
         host.setAgentId(getAgentId());

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/AbstractAgentTaskServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/AbstractAgentTaskServiceImpl.java
@@ -38,7 +38,7 @@ public abstract class AbstractAgentTaskServiceImpl implements AgentTaskService {
         }
 
         List<AgentTaskDetailDTO> agentTaskDetailList;
-        boolean hasIpInfo = StringUtils.isNotEmpty(agentTasks.get(0).getCloudIp());
+        boolean hasIpInfo = agentTasks.stream().anyMatch(agentTask -> StringUtils.isNotEmpty(agentTask.getCloudIp()));
         if (!hasIpInfo) {
             // 从当前版本开始AgentTask不会包含ip信息，需要从StepInstance反查
             Map<Long, HostDTO> hosts = stepInstanceService.computeStepHosts(stepInstance, HostDTO::getHostId);
@@ -54,7 +54,7 @@ public abstract class AbstractAgentTaskServiceImpl implements AgentTaskService {
                     return agentTaskDetail;
                 }).collect(Collectors.toList());
         } else {
-            // 历史版本AgentTask会包含ip信息
+            // 历史版本AgentTask会包含ipv4信息
             agentTaskDetailList = agentTasks.stream()
                 .map(agentTask -> {
                     AgentTaskDetailDTO agentTaskDetail = new AgentTaskDetailDTO(agentTask);

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/HostEventsHandler.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/HostEventsHandler.java
@@ -109,16 +109,6 @@ public class HostEventsHandler extends EventsHandler<HostEventDetail> {
         }
     }
 
-    private void deleteHostWithoutIp(ApplicationHostDTO hostInfoDTO) {
-        int affectedRowNum = applicationHostDAO.deleteBizHostInfoById(null, hostInfoDTO.getHostId());
-        log.info(
-            "{} host deleted, id={} ,ip={}",
-            affectedRowNum,
-            hostInfoDTO.getHostId(),
-            hostInfoDTO.getIp()
-        );
-    }
-
     private List<String> buildAgentIdByMultiIp(Long cloudId, String multiIp) {
         if (StringUtils.isBlank(multiIp)) {
             return Collections.emptyList();


### PR DESCRIPTION
#1523 

- 修改内容
1. 优化日志打印，不再打印header（包含敏感信息)
2. 优化日志打印，GSE 脚本任务执行结果不再打印具体的日志内容，避免产生巨大的日志文件
3. 修复复制ipv6失败的问题