### PR TITLE
bugfix: [ipv6]第三方文件源分发文件，会产生重复的执行结果 #1563 

### DIFF
--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/CommonCredential.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/CommonCredential.java
@@ -22,14 +22,24 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.file_gateway.client;
+package com.tencent.bk.job.common.model.dto;
 
-import com.tencent.bk.job.logsvr.api.ServiceLogResource;
-import org.springframework.cloud.openfeign.FeignClient;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
-/**
- * 日志服务远程调用客户端
- */
-@FeignClient(value = "job-logsvr", contextId = "log")
-public interface LogServiceResourceClient extends ServiceLogResource {
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@EqualsAndHashCode
+public class CommonCredential {
+    String accessKey;
+    String secretKey;
+    String username;
+    String password;
+    /**
+     * 类型
+     */
+    private String type;
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/util/JobSrcFileUtils.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/util/JobSrcFileUtils.java
@@ -137,29 +137,13 @@ public class JobSrcFileUtils {
                         if (predicate.test(sourceHost)) {
                             // 第三方源文件的displayName不同
                             if (isThirdFile) {
-                                sendFiles.add(new JobFile(
-                                    TaskFileTypeEnum.FILE_SOURCE,
-                                    sourceHost,
+                                sendFiles.add(new JobFile(TaskFileTypeEnum.FILE_SOURCE, sourceHost,
                                     file.getThirdFilePathWithFileSourceName(),
                                     file.getThirdFilePathWithFileSourceName(),
-                                    dir,
-                                    fileName,
-                                    stepInstance.getAppId(),
-                                    accountId,
-                                    accountAlias
-                                ));
+                                    dir, fileName, stepInstance.getAppId(), accountId, accountAlias));
                             } else {
-                                sendFiles.add(new JobFile(
-                                    TaskFileTypeEnum.SERVER,
-                                    sourceHost,
-                                    filePath,
-                                    filePath,
-                                    dir,
-                                    fileName,
-                                    stepInstance.getAppId(),
-                                    accountId,
-                                    accountAlias
-                                ));
+                                sendFiles.add(new JobFile(TaskFileTypeEnum.SERVER, sourceHost, filePath, filePath, dir,
+                                    fileName, stepInstance.getAppId(), accountId, accountAlias));
                             }
                         }
                     }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/util/JobSrcFileUtils.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/util/JobSrcFileUtils.java
@@ -137,13 +137,29 @@ public class JobSrcFileUtils {
                         if (predicate.test(sourceHost)) {
                             // 第三方源文件的displayName不同
                             if (isThirdFile) {
-                                sendFiles.add(new JobFile(TaskFileTypeEnum.FILE_SOURCE, sourceHost,
+                                sendFiles.add(new JobFile(
+                                    TaskFileTypeEnum.FILE_SOURCE,
+                                    sourceHost,
                                     file.getThirdFilePathWithFileSourceName(),
                                     file.getThirdFilePathWithFileSourceName(),
-                                    dir, fileName, stepInstance.getAppId(), accountId, accountAlias));
+                                    dir,
+                                    fileName,
+                                    stepInstance.getAppId(),
+                                    accountId,
+                                    accountAlias
+                                ));
                             } else {
-                                sendFiles.add(new JobFile(TaskFileTypeEnum.SERVER, sourceHost, filePath, filePath, dir,
-                                    fileName, stepInstance.getAppId(), accountId, accountAlias));
+                                sendFiles.add(new JobFile(
+                                    TaskFileTypeEnum.SERVER,
+                                    sourceHost,
+                                    filePath,
+                                    filePath,
+                                    dir,
+                                    fileName,
+                                    stepInstance.getAppId(),
+                                    accountId,
+                                    accountAlias
+                                ));
                             }
                         }
                     }
@@ -199,8 +215,7 @@ public class JobSrcFileUtils {
     public static Map<String, String> buildSourceFileDisplayMapping(Set<JobFile> sourceFiles, String localUploadDir) {
         Map<String, String> sourceFileDisplayMap = new HashMap<>();
         sourceFiles.forEach(sourceFile -> {
-            Pair<String, String> pair = FilePathUtils.parseDirAndFileName(sourceFile.getFilePath());
-            String standardPath = FilePathUtils.standardizedDirPath(pair.getLeft()) + pair.getRight();
+            String standardPath = sourceFile.getStandardFilePath();
             if (sourceFile.getFileType() == TaskFileTypeEnum.LOCAL && !standardPath.startsWith(localUploadDir)) {
                 sourceFileDisplayMap.put(PathUtil.joinFilePath(localUploadDir, standardPath),
                     sourceFile.getDisplayFilePath());

--- a/src/backend/job-file-gateway/api-job-file-gateway/build.gradle
+++ b/src/backend/job-file-gateway/api-job-file-gateway/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     api project(':commons:common')
     api project(':commons:common-i18n')
     api project(':commons:common-iam')
-    api project(":job-logsvr:api-job-logsvr")
     api project(":job-file-gateway:api-job-file-gateway-worker")
     api(project(":commons:common-api"))
     api project(':commons:esb-sdk')

--- a/src/backend/job-file-gateway/api-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/model/resp/inner/FileLogPieceDTO.java
+++ b/src/backend/job-file-gateway/api-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/model/resp/inner/FileLogPieceDTO.java
@@ -1,0 +1,134 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.file_gateway.model.resp.inner;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * 文件下载日志
+ */
+@ApiModel("单个文件的一条下载日志")
+@Data
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class FileLogPieceDTO {
+
+    /**
+     * 下载文件的file-worker的云区域ID:IP
+     */
+    @JsonProperty("srcIp")
+    private String srcIp;
+
+    /**
+     * 下载文件的file-worker的云区域ID:IP - 显示
+     */
+    @JsonProperty("displaySrcIp")
+    private String displaySrcIp;
+
+    /**
+     * 源文件路径 - 真实路径
+     */
+    @JsonProperty("srcFile")
+    private String srcFile;
+
+    /**
+     * 源文件路径 - 用于显示
+     */
+    @JsonProperty("displaySrcFile")
+    private String displaySrcFile;
+
+    /**
+     * 文件大小
+     */
+    @JsonProperty("size")
+    private String size;
+
+    /**
+     * 文件任务状态
+     */
+    @JsonProperty("status")
+    private Integer status;
+
+    /**
+     * 文件任务状态描述
+     */
+    @JsonProperty("statusDesc")
+    private String statusDesc;
+
+    /**
+     * 速度
+     */
+    @JsonProperty("speed")
+    private String speed;
+
+    /**
+     * 进度
+     */
+    @JsonProperty("process")
+    private String process;
+
+    /**
+     * 日志内容
+     */
+    @JsonProperty("content")
+    private String content;
+
+    public FileLogPieceDTO(String srcIp,
+                           String displaySrcIp,
+                           String srcFile,
+                           String displaySrcFile,
+                           String size,
+                           Integer status,
+                           String statusDesc,
+                           String speed,
+                           String process,
+                           String content) {
+        this.srcIp = srcIp;
+        this.displaySrcIp = displaySrcIp;
+        this.srcFile = srcFile;
+        this.displaySrcFile = displaySrcFile;
+        this.size = size;
+        this.status = status;
+        this.statusDesc = statusDesc;
+        this.speed = speed;
+        this.process = process;
+        this.content = content;
+    }
+
+    public String getDisplaySrcIp() {
+        if (StringUtils.isNotEmpty(this.displaySrcIp)) {
+            return this.displaySrcIp;
+        } else {
+            return this.srcIp;
+        }
+    }
+}
+
+

--- a/src/backend/job-file-gateway/api-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/model/resp/inner/FileSourceTaskStatusDTO.java
+++ b/src/backend/job-file-gateway/api-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/model/resp/inner/FileSourceTaskStatusDTO.java
@@ -27,7 +27,6 @@ package com.tencent.bk.job.file_gateway.model.resp.inner;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 import com.tencent.bk.job.file_gateway.consts.TaskStatusEnum;
-import com.tencent.bk.job.logsvr.model.service.ServiceHostLogDTO;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -50,7 +49,7 @@ public class FileSourceTaskStatusDTO {
      * 文件源文件路径->文件在机器上的真实路径
      */
     Map<String, String> filePathMap;
-    List<ServiceHostLogDTO> logList;
+    List<ThirdFileSourceTaskLogDTO> logList;
     Boolean logEnd;
 
     public boolean isDone() {

--- a/src/backend/job-file-gateway/api-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/model/resp/inner/ThirdFileSourceTaskLogDTO.java
+++ b/src/backend/job-file-gateway/api-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/model/resp/inner/ThirdFileSourceTaskLogDTO.java
@@ -22,24 +22,41 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.manage.model.credential;
+package com.tencent.bk.job.file_gateway.model.resp.inner;
 
-import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
-@AllArgsConstructor
+import java.util.ArrayList;
+import java.util.List;
+
+@ApiModel("第三方文件源文件下载任务日志")
 @Data
-@EqualsAndHashCode
-public class CommonCredential {
-    String accessKey;
-    String secretKey;
-    String username;
-    String password;
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class ThirdFileSourceTaskLogDTO {
     /**
-     * 类型
+     * 文件源下载任务ID
      */
-    private String type;
+    @ApiModelProperty("文件源下载任务ID")
+    private String taskId;
+
+    /**
+     * 任务执行所在的file-worker的cloudIp
+     */
+    @ApiModelProperty(value = "任务执行所在的file-worker的云区域ID:IP")
+    private String ip;
+
+    /**
+     * 文件下载日志
+     */
+    private List<FileLogPieceDTO> fileTaskLogs;
+
+    public void addFileTaskLog(FileLogPieceDTO fileTaskDetailLog) {
+        if (fileTaskLogs == null) {
+            fileTaskLogs = new ArrayList<>();
+        }
+        fileTaskLogs.add(fileTaskDetailLog);
+    }
 }

--- a/src/backend/job-file-gateway/service-job-file-gateway/build.gradle
+++ b/src/backend/job-file-gateway/service-job-file-gateway/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     api project(":commons:common-web")
     api project(":commons:common-redis")
     api project(":job-manage:api-job-manage")
-    api project(":job-execute:api-job-execute")
     api project(":job-file-worker-sdk:api-job-file-worker-sdk")
     api project(":job-file-gateway:api-job-file-gateway")
     api project(":job-file-gateway:model-job-file-gateway")

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/CredentialService.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/CredentialService.java
@@ -24,7 +24,7 @@
 
 package com.tencent.bk.job.file_gateway.service;
 
-import com.tencent.bk.job.manage.model.credential.CommonCredential;
+import com.tencent.bk.job.common.model.dto.CommonCredential;
 
 
 public interface CredentialService {

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/CredentialServiceImpl.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/CredentialServiceImpl.java
@@ -28,7 +28,7 @@ import com.tencent.bk.job.common.model.InternalResponse;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 import com.tencent.bk.job.file_gateway.client.ServiceCredentialResourceClient;
 import com.tencent.bk.job.file_gateway.service.CredentialService;
-import com.tencent.bk.job.manage.model.credential.CommonCredential;
+import com.tencent.bk.job.common.model.dto.CommonCredential;
 import com.tencent.bk.job.manage.model.inner.resp.ServiceCredentialDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.helpers.FormattingTuple;

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/FileSourceTaskServiceImpl.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/FileSourceTaskServiceImpl.java
@@ -47,16 +47,16 @@ import com.tencent.bk.job.file_gateway.model.dto.FileSourceDTO;
 import com.tencent.bk.job.file_gateway.model.dto.FileSourceTaskDTO;
 import com.tencent.bk.job.file_gateway.model.dto.FileTaskDTO;
 import com.tencent.bk.job.file_gateway.model.dto.FileWorkerDTO;
+import com.tencent.bk.job.file_gateway.model.resp.inner.FileLogPieceDTO;
 import com.tencent.bk.job.file_gateway.model.resp.inner.FileSourceTaskStatusDTO;
 import com.tencent.bk.job.file_gateway.model.resp.inner.TaskInfoDTO;
+import com.tencent.bk.job.file_gateway.model.resp.inner.ThirdFileSourceTaskLogDTO;
 import com.tencent.bk.job.file_gateway.service.DispatchService;
 import com.tencent.bk.job.file_gateway.service.FileSourceTaskService;
 import com.tencent.bk.job.file_gateway.service.context.TaskContext;
 import com.tencent.bk.job.file_gateway.service.context.impl.DefaultTaskContext;
 import com.tencent.bk.job.file_gateway.service.listener.FileTaskStatusChangeListener;
 import com.tencent.bk.job.file_gateway.service.remote.FileSourceTaskReqGenService;
-import com.tencent.bk.job.logsvr.model.service.ServiceFileTaskLogDTO;
-import com.tencent.bk.job.logsvr.model.service.ServiceHostLogDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.DSLContext;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -192,11 +192,9 @@ public class FileSourceTaskServiceImpl implements FileSourceTaskService {
                           String content) {
         String taskId = fileSourceTaskDTO.getId();
         String fileSizeStr = FileSizeUtil.getFileSizeStr(fileSize);
-        ServiceHostLogDTO serviceHostLogDTO = new ServiceHostLogDTO();
-        serviceHostLogDTO.setStepInstanceId(fileSourceTaskDTO.getStepInstanceId());
-        serviceHostLogDTO.setExecuteCount(fileSourceTaskDTO.getExecuteCount());
+        ThirdFileSourceTaskLogDTO thirdFileSourceTaskLog = new ThirdFileSourceTaskLogDTO();
         String sourceIp = fileWorkerDTO.getCloudAreaId().toString() + ":" + fileWorkerDTO.getInnerIp();
-        serviceHostLogDTO.setIp(sourceIp);
+        thirdFileSourceTaskLog.setIp(sourceIp);
         // 追加文件源名称
         // 日志定位坐标：（文件源，文件路径），需要区分不同文件源下相同文件路径的日志
         FileSourceDTO fileSourceDTO = fileSourceDAO.getFileSourceById(dslContext, fileSourceTaskDTO.getFileSourceId());
@@ -205,21 +203,20 @@ public class FileSourceTaskServiceImpl implements FileSourceTaskService {
                 ArrayUtil.toArray("fileSourceId:" + fileSourceTaskDTO.getFileSourceId()));
         }
         String filePathWithSourceAlias = PathUtil.joinFilePath(fileSourceDTO.getAlias(), filePath);
-        List<ServiceFileTaskLogDTO> fileTaskLogs = new ArrayList<>();
-        ServiceFileTaskLogDTO serviceFileTaskLogDTO = new ServiceFileTaskLogDTO();
-        serviceFileTaskLogDTO.setMode(0);
-        serviceFileTaskLogDTO.setContent("FileName: " + filePathWithSourceAlias + " FileSize: " + fileSizeStr + " " +
+        List<FileLogPieceDTO> fileLogPieceList = new ArrayList<>();
+        FileLogPieceDTO fileLogPiece = new FileLogPieceDTO();
+        fileLogPiece.setContent("FileName: " + filePathWithSourceAlias + " FileSize: " + fileSizeStr + " " +
             "Speed: " + speed + " Progress: " + progress + "%" + " Detail: " + content);
-        serviceFileTaskLogDTO.setDisplaySrcFile(filePathWithSourceAlias);
-        serviceFileTaskLogDTO.setProcess("" + progress + "%");
-        serviceFileTaskLogDTO.setSize(fileSizeStr);
-        serviceFileTaskLogDTO.setSrcIp(sourceIp);
-        serviceFileTaskLogDTO.setStatus(FileDistStatusEnum.PULLING.getValue());
-        serviceFileTaskLogDTO.setStatusDesc(FileDistStatusEnum.PULLING.getName());
-        fileTaskLogs.add(serviceFileTaskLogDTO);
-        serviceHostLogDTO.setFileTaskLogs(fileTaskLogs);
+        fileLogPiece.setDisplaySrcFile(filePathWithSourceAlias);
+        fileLogPiece.setProcess("" + progress + "%");
+        fileLogPiece.setSize(fileSizeStr);
+        fileLogPiece.setSrcIp(sourceIp);
+        fileLogPiece.setStatus(FileDistStatusEnum.PULLING.getValue());
+        fileLogPiece.setStatusDesc(FileDistStatusEnum.PULLING.getName());
+        fileLogPieceList.add(fileLogPiece);
+        thirdFileSourceTaskLog.setFileTaskLogs(fileLogPieceList);
         // 写入Redis
-        redisTemplate.opsForList().rightPush(PREFIX_REDIS_TASK_LOG + taskId, serviceHostLogDTO);
+        redisTemplate.opsForList().rightPush(PREFIX_REDIS_TASK_LOG + taskId, thirdFileSourceTaskLog);
         // 一小时后过期
         redisTemplate.expireAt(PREFIX_REDIS_TASK_LOG + taskId, new Date(System.currentTimeMillis() + 3600 * 1000));
     }
@@ -343,11 +340,11 @@ public class FileSourceTaskServiceImpl implements FileSourceTaskService {
             logEnd = logSize;
         }
         log.debug("logStart={},logEnd={}", logStart, logEnd);
-        List<ServiceHostLogDTO> logDTOList = null;
+        List<ThirdFileSourceTaskLogDTO> logDTOList = null;
         List<Object> logObjList = redisTemplate.opsForList().range(PREFIX_REDIS_TASK_LOG + taskId, logStart,
             logEnd);
         if (logObjList != null) {
-            logDTOList = logObjList.stream().map(obj -> (ServiceHostLogDTO) obj).collect(Collectors.toList());
+            logDTOList = logObjList.stream().map(obj -> (ThirdFileSourceTaskLogDTO) obj).collect(Collectors.toList());
         }
         log.debug("logDTOList={}", logDTOList);
         fileSourceTaskStatusDTO.setLogList(logDTOList);

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/remote/impl/BaseRemoteFileReqGenServiceImpl.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/remote/impl/BaseRemoteFileReqGenServiceImpl.java
@@ -30,7 +30,7 @@ import com.tencent.bk.job.file.worker.model.req.BaseReq;
 import com.tencent.bk.job.file_gateway.model.dto.FileSourceDTO;
 import com.tencent.bk.job.file_gateway.model.dto.FileWorkerDTO;
 import com.tencent.bk.job.file_gateway.service.CredentialService;
-import com.tencent.bk.job.manage.model.credential.CommonCredential;
+import com.tencent.bk.job.common.model.dto.CommonCredential;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;

--- a/src/backend/job-file-worker-sdk/api-job-file-worker-sdk/build.gradle
+++ b/src/backend/job-file-worker-sdk/api-job-file-worker-sdk/build.gradle
@@ -24,7 +24,6 @@
 
 dependencies {
     api project(':commons:common')
-    api project(':job-manage:api-job-manage')
     api project(':job-file-gateway:api-job-file-gateway-worker')
     implementation "org.springframework:spring-web"
     implementation "javax.ws.rs:javax.ws.rs-api"

--- a/src/backend/job-file-worker-sdk/api-job-file-worker-sdk/src/main/java/com/tencent/bk/job/file/worker/model/req/BaseReq.java
+++ b/src/backend/job-file-worker-sdk/api-job-file-worker-sdk/src/main/java/com/tencent/bk/job/file/worker/model/req/BaseReq.java
@@ -25,7 +25,7 @@
 package com.tencent.bk.job.file.worker.model.req;
 
 import com.tencent.bk.job.common.util.json.SkipLogFields;
-import com.tencent.bk.job.manage.model.credential.CommonCredential;
+import com.tencent.bk.job.common.model.dto.CommonCredential;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 

--- a/src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/artifactory/service/ArtifactoryBaseService.java
+++ b/src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/artifactory/service/ArtifactoryBaseService.java
@@ -25,7 +25,7 @@
 package com.tencent.bk.job.file.worker.artifactory.service;
 
 import com.tencent.bk.job.file.worker.model.req.BaseReq;
-import com.tencent.bk.job.manage.model.credential.CommonCredential;
+import com.tencent.bk.job.common.model.dto.CommonCredential;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;

--- a/src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/cos/service/COSBaseService.java
+++ b/src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/cos/service/COSBaseService.java
@@ -26,7 +26,7 @@ package com.tencent.bk.job.file.worker.cos.service;
 
 import com.tencent.bk.job.file.worker.cos.JobTencentInnerCOSClient;
 import com.tencent.bk.job.file.worker.model.req.BaseReq;
-import com.tencent.bk.job.manage.model.credential.CommonCredential;
+import com.tencent.bk.job.common.model.dto.CommonCredential;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/inner/resp/ServiceCredentialDTO.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/inner/resp/ServiceCredentialDTO.java
@@ -24,7 +24,7 @@
 
 package com.tencent.bk.job.manage.model.inner.resp;
 
-import com.tencent.bk.job.manage.model.credential.CommonCredential;
+import com.tencent.bk.job.common.model.dto.CommonCredential;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/CredentialCreateUpdateReq.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/CredentialCreateUpdateReq.java
@@ -25,7 +25,7 @@
 package com.tencent.bk.job.manage.model.web.request;
 
 import com.tencent.bk.job.manage.common.consts.CredentialTypeEnum;
-import com.tencent.bk.job.manage.model.credential.CommonCredential;
+import com.tencent.bk.job.common.model.dto.CommonCredential;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/impl/CredentialDAOImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/impl/CredentialDAOImpl.java
@@ -33,7 +33,7 @@ import com.tencent.bk.job.common.util.crypto.AESUtils;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 import com.tencent.bk.job.manage.config.JobTicketConfig;
 import com.tencent.bk.job.manage.dao.CredentialDAO;
-import com.tencent.bk.job.manage.model.credential.CommonCredential;
+import com.tencent.bk.job.common.model.dto.CommonCredential;
 import com.tencent.bk.job.manage.model.dto.CredentialDTO;
 import com.tencent.bk.job.manage.model.inner.resp.ServiceCredentialDisplayDTO;
 import io.micrometer.core.instrument.util.StringUtils;

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/model/dto/CredentialDTO.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/model/dto/CredentialDTO.java
@@ -25,7 +25,7 @@
 package com.tencent.bk.job.manage.model.dto;
 
 import com.tencent.bk.job.manage.common.consts.CredentialTypeEnum;
-import com.tencent.bk.job.manage.model.credential.CommonCredential;
+import com.tencent.bk.job.common.model.dto.CommonCredential;
 import com.tencent.bk.job.manage.model.inner.resp.ServiceCredentialDTO;
 import com.tencent.bk.job.manage.model.web.vo.CredentialVO;
 import lombok.AllArgsConstructor;


### PR DESCRIPTION
1. 第三方源文件准备过程日志保存前解析主机信息补充hostId；
2. file-gateway解除对api-logsvr的依赖；
3. 更正文件路径与展示路径的映射关系map数据，修复产生重复日志条目的问题；
4. 重构部分代码。