### PR TITLE
feature: 3.6.x版本移除对agentId的依赖 #1615

### DIFF
--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/HostDTO.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/HostDTO.java
@@ -205,20 +205,6 @@ public class HostDTO implements Cloneable {
     }
 
     /**
-     * 获取最终的agentId，若agentId不存在，则使用cloudIp作为agentId
-     *
-     * @return 最终的agentId
-     */
-    @JsonIgnore
-    public String getFinalAgentId() {
-        if (StringUtils.isNotBlank(agentId)) {
-            return agentId;
-        } else {
-            return toCloudIp();
-        }
-    }
-
-    /**
      * 获取主机的唯一KEY，用于去重等操作
      *
      * @return 主机KEY

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/AbstractGseTaskStartCommand.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/AbstractGseTaskStartCommand.java
@@ -152,8 +152,7 @@ public abstract class AbstractGseTaskStartCommand extends AbstractGseTaskCommand
         this.requestId = requestId;
         this.stepInstanceService = stepInstanceService;
 
-        this.agentIdHostMap = stepInstanceService.computeStepHosts(stepInstance,
-            host -> host.getAgentId() != null ? host.getAgentId() : host.toCloudIp());
+        this.agentIdHostMap = stepInstanceService.computeStepHosts(stepInstance, HostDTO::toCloudIp);
     }
 
 

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/listener/GseStepEventHandler.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/listener/GseStepEventHandler.java
@@ -58,7 +58,6 @@ import com.tencent.bk.job.logsvr.consts.FileTaskModeEnum;
 import com.tencent.bk.job.manage.common.consts.task.TaskStepTypeEnum;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -340,12 +339,7 @@ public class GseStepEventHandler implements StepEventHandler {
         agentTask.setStatus(status);
         agentTask.setFileTaskMode(FileTaskModeEnum.DOWNLOAD);
         agentTask.setHostId(host.getHostId());
-        if (StringUtils.isEmpty(host.getAgentId())) {
-            // 兼容老的Agent,没有AgentId,需要使用{bk_cloud_id:ip}的格式作为agentId传给GSE
-            agentTask.setAgentId(host.toCloudIp());
-        } else {
-            agentTask.setAgentId(host.getAgentId());
-        }
+        agentTask.setAgentId(host.toCloudIp());
         return agentTask;
     }
 

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/third/ThirdFilePrepareTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/third/ThirdFilePrepareTask.java
@@ -256,7 +256,7 @@ public class ThirdFilePrepareTask implements ContinuousScheduledTask, JobTaskCon
         hostDTO.setHostId(serviceHostDTO.getHostId());
         hostDTO.setBkCloudId(serviceHostDTO.getCloudAreaId());
         hostDTO.setIp(serviceHostDTO.getIp());
-        hostDTO.setAgentId(serviceHostDTO.getFinalAgentId());
+        hostDTO.setAgentId(serviceHostDTO.getCloudIp());
     }
 
     private void handleFileSourceTaskResult(

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/AbstractResultHandleTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/AbstractResultHandleTask.java
@@ -245,8 +245,7 @@ public abstract class AbstractResultHandleTask<T> implements ContinuousScheduled
         });
         this.notStartedTargetAgentIds.addAll(targetAgentIds);
 
-        this.agentIdHostMap = stepInstanceService.computeStepHosts(stepInstance,
-            host -> host.getAgentId() != null ? host.getAgentId() : host.toCloudIp());
+        this.agentIdHostMap = stepInstanceService.computeStepHosts(stepInstance, HostDTO::toCloudIp);
 
         // 如果是执行方案，需要初始化全局变量
         if (taskInstance.isPlanInstance()) {

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/AgentServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/AgentServiceImpl.java
@@ -103,7 +103,7 @@ public class AgentServiceImpl implements AgentService {
             String agentBindCloudIp = Consts.DEFAULT_CLOUD_ID + ":" + agentBindIp;
             ServiceHostDTO host = hostService.getHost(HostDTO.fromCloudIp(agentBindCloudIp));
             agentHost = HostDTO.fromHostIdAndCloudIp(host.getHostId(), agentBindCloudIp);
-            agentHost.setAgentId(agentHost.getFinalAgentId());
+            agentHost.setAgentId(agentHost.toCloudIp());
             return agentHost;
         }
     }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/TaskExecuteServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/TaskExecuteServiceImpl.java
@@ -825,11 +825,11 @@ public class TaskExecuteServiceImpl implements TaskExecuteService {
             host.setBkCloudId(hostDetail.getBkCloudId());
             host.setIp(hostDetail.getIp());
             // 兼容没有agent_id的主机，按照与GSE的约定，按照{云区域ID:ip}的方式构造agent_id
-            host.setAgentId(StringUtils.isEmpty(hostDetail.getAgentId()) ? host.toCloudIp() : hostDetail.getAgentId());
+            host.setAgentId(host.toCloudIp());
         } else {
             HostDTO hostDetail = hostMap.get("hostIp:" + host.toCloudIp());
             // 兼容没有agent_id的主机，按照与GSE的约定，按照{云区域ID:ip}的方式构造agent_id
-            host.setAgentId(StringUtils.isEmpty(hostDetail.getAgentId()) ? host.toCloudIp() : hostDetail.getAgentId());
+            host.setAgentId(host.toCloudIp());
             host.setHostId(hostDetail.getHostId());
         }
     }

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/inner/ServiceHostDTO.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/inner/ServiceHostDTO.java
@@ -32,7 +32,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * 主机
@@ -48,11 +47,6 @@ public class ServiceHostDTO {
      * 主机ID
      */
     private Long hostId;
-
-    /**
-     * AgentID
-     */
-    private String agentId;
 
     /**
      * 云区域ID
@@ -79,14 +73,6 @@ public class ServiceHostDTO {
         return cloudAreaId + ":" + ip;
     }
 
-    @JsonIgnore
-    public String getFinalAgentId() {
-        if (StringUtils.isNotBlank(agentId)) {
-            return agentId;
-        }
-        return getCloudIp();
-    }
-
     public static ServiceHostDTO fromApplicationHostDTO(ApplicationHostDTO host) {
         return ServiceHostDTO.builder()
             .bizId(host.getBizId())
@@ -94,7 +80,6 @@ public class ServiceHostDTO {
             .hostId(host.getHostId())
             .cloudAreaId(host.getCloudAreaId())
             .ip(host.getIp())
-            .agentId(host.getAgentId())
             .build();
     }
 }


### PR DESCRIPTION
1. 考虑到蓝鲸平台版本依赖情况，所以在执行引擎之外的获取主机的地方，删除agentId这个概念，避免因为cmdb/gse 2.0独立更新的情况下Job可能使用了真实的agentId而导致错误

2. 该PR不需要合入3.7.x(IPv6)分支