### PR TITLE
bugfix: 作业平台调用快速分发文件API，transferMode参数不生效 #1624

### DIFF
--- a/src/backend/job-execute/api-job-execute/src/main/java/com/tencent/bk/job/execute/model/esb/v3/request/EsbFastTransferFileV3Request.java
+++ b/src/backend/job-execute/api-job-execute/src/main/java/com/tencent/bk/job/execute/model/esb/v3/request/EsbFastTransferFileV3Request.java
@@ -110,6 +110,7 @@ public class EsbFastTransferFileV3Request extends EsbAppScopeReq {
     /**
      * 传输模式。1-严谨模式，2-强制模式
      */
+    @JsonProperty("transfer_mode")
     private Integer transferMode;
 
     public void trimIps() {


### PR DESCRIPTION
#1624