### PR TITLE
feature: Job对接GSE1.0/2.0支持灰度 #1602

### DIFF
--- a/src/backend/commons/cmdb-sdk-model/src/main/java/com/tencent/bk/job/common/cc/model/DynamicGroupHostPropDTO.java
+++ b/src/backend/commons/cmdb-sdk-model/src/main/java/com/tencent/bk/job/common/cc/model/DynamicGroupHostPropDTO.java
@@ -25,11 +25,7 @@
 package com.tencent.bk.job.common.cc.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.tencent.bk.job.common.model.dto.ApplicationHostDTO;
-import com.tencent.bk.job.common.util.ip.IpUtils;
 import lombok.Data;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 
@@ -60,26 +56,4 @@ public class DynamicGroupHostPropDTO {
     @JsonProperty("bk_cloud_id")
     private List<CcCloudIdDTO> cloudIdList;
 
-    public String getFinalAgentId() {
-        if (StringUtils.isNotBlank(agentId)) {
-            return agentId;
-        }
-        if (CollectionUtils.isNotEmpty(cloudIdList) && StringUtils.isNotBlank(ip)) {
-            return IpUtils.buildCloudIpListByMultiIp(cloudIdList.get(0).getInstanceId(), ip).get(0);
-        }
-        return null;
-    }
-
-    public ApplicationHostDTO toApplicationHostDTO() {
-        ApplicationHostDTO applicationHostDTO = new ApplicationHostDTO();
-        applicationHostDTO.setHostId(id);
-        applicationHostDTO.setHostName(name);
-        applicationHostDTO.setIp(ip);
-        applicationHostDTO.setIpv6(ipv6);
-        applicationHostDTO.setAgentId(agentId);
-        if (CollectionUtils.isNotEmpty(cloudIdList)) {
-            applicationHostDTO.setCloudAreaId(cloudIdList.get(0).getInstanceId());
-        }
-        return applicationHostDTO;
-    }
 }

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/ApplicationHostDTO.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/ApplicationHostDTO.java
@@ -296,12 +296,4 @@ public class ApplicationHostDTO {
         return host;
     }
 
-    public String extractFirstIp() {
-        if (StringUtils.isNotEmpty(ip) && ip.contains(",")) {
-            return ip.split(",")[0];
-        } else {
-            return ip;
-        }
-    }
-
 }

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/ApplicationHostDTO.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/ApplicationHostDTO.java
@@ -65,7 +65,7 @@ public class ApplicationHostDTO {
      */
     private Long bizId;
     /**
-     * IP
+     * IPv4(主机的第一个IPv4地址,完整的IPv4地址使用displayIp字段)
      */
     private String ip;
     /**
@@ -78,7 +78,7 @@ public class ApplicationHostDTO {
     private String agentId;
 
     /**
-     * 展示用的IP
+     * 完整的IPv4地址
      */
     private String displayIp;
     /**
@@ -290,13 +290,13 @@ public class ApplicationHostDTO {
         host.setHostId(hostId);
         host.setBkCloudId(cloudAreaId);
         host.setIp(ip);
-        host.setIpv6(extractFirstIp(ipv6));
+        host.setIpv6(ipv6);
         host.setAgentId(agentId);
         host.setAlive(getAgentAliveValue());
         return host;
     }
 
-    private String extractFirstIp(String ip) {
+    public String extractFirstIp() {
         if (StringUtils.isNotEmpty(ip) && ip.contains(",")) {
             return ip.split(",")[0];
         } else {

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/GseClient.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/GseClient.java
@@ -1,5 +1,7 @@
 package com.tencent.bk.job.common.gse;
 
+import com.tencent.bk.job.common.constant.ErrorCode;
+import com.tencent.bk.job.common.exception.InternalException;
 import com.tencent.bk.job.common.gse.util.AgentUtils;
 import com.tencent.bk.job.common.gse.v1.GseV1ApiClient;
 import com.tencent.bk.job.common.gse.v2.GseV2ApiClient;
@@ -14,6 +16,7 @@ import com.tencent.bk.job.common.gse.v2.model.TransferFileRequest;
 import com.tencent.bk.job.common.gse.v2.model.req.ListAgentStateReq;
 import com.tencent.bk.job.common.gse.v2.model.resp.AgentState;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -41,6 +44,10 @@ public class GseClient implements IGseClient {
     }
 
     private IGseClient chooseGseApiClientByAgentId(String agentId) {
+        if (StringUtils.isEmpty(agentId)) {
+            log.error("Empty agentId!");
+            throw new InternalException("AgentId is empty", ErrorCode.INTERNAL_ERROR);
+        }
         if (AgentUtils.isGseV1AgentId(agentId)) {
             log.debug("Choose GseV1ApiClient, agentId: {}", agentId);
             return gseV1ApiClient;

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/service/AgentStateClient.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/service/AgentStateClient.java
@@ -24,7 +24,6 @@
 
 package com.tencent.bk.job.common.gse.service;
 
-import com.tencent.bk.job.common.exception.InternalException;
 import com.tencent.bk.job.common.gse.v2.model.resp.AgentState;
 
 import java.util.List;
@@ -42,23 +41,6 @@ public interface AgentStateClient {
      * @return Agent状态对象
      */
     AgentState getAgentState(String agentId);
-
-    /**
-     * 根据agentId获取agent存活状态
-     *
-     * @param agentId AgentId
-     * @return Agent是否存活
-     */
-    boolean getAgentAliveStatus(String agentId);
-
-    /**
-     * 从多个agentId中选择一个，优先选择agent状态正常的，都不正常选第一个
-     *
-     * @param agentIdList agentId列表
-     * @return 选择的agentId
-     * @throws InternalException agentIdList为空时抛出异常
-     */
-    String chooseOneAgentIdPreferAlive(List<String> agentIdList);
 
     /**
      * 根据agentId批量获取agent状态

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/service/AgentStateClientImpl.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/service/AgentStateClientImpl.java
@@ -33,7 +33,6 @@ import com.tencent.bk.job.common.gse.util.AgentUtils;
 import com.tencent.bk.job.common.gse.v2.model.req.ListAgentStateReq;
 import com.tencent.bk.job.common.gse.v2.model.resp.AgentState;
 import com.tencent.bk.job.common.util.ConcurrencyUtil;
-import com.tencent.bk.job.common.util.LogUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -82,36 +81,6 @@ public class AgentStateClientImpl implements AgentStateClient {
             throw new InternalException(ErrorCode.GSE_API_DATA_ERROR, new String[]{msg.getMessage()});
         }
         return agentStateList.get(0);
-    }
-
-    @Override
-    public boolean getAgentAliveStatus(String agentId) {
-        AgentState agentState = getAgentState(agentId);
-        return AgentStatusEnum.fromAgentState(agentState) == AgentStatusEnum.ALIVE;
-    }
-
-    @Override
-    public String chooseOneAgentIdPreferAlive(List<String> agentIdList) {
-        if (CollectionUtils.isEmpty(agentIdList)) {
-            throw new InternalException("agentIdList cannot be empty", ErrorCode.INTERNAL_ERROR);
-        }
-        try {
-            Map<String, Boolean> map = batchGetAgentAliveStatus(agentIdList);
-            for (Map.Entry<String, Boolean> entry : map.entrySet()) {
-                String agentId = entry.getKey();
-                Boolean alive = entry.getValue();
-                if (alive) {
-                    return agentId;
-                }
-            }
-        } catch (Exception e) {
-            FormattingTuple msg = MessageFormatter.format(
-                "Fail to get agentState by agentIdList:{}",
-                LogUtil.buildListLog(agentIdList, 20)
-            );
-            log.warn(msg.getMessage(), e);
-        }
-        return agentIdList.get(0);
     }
 
     @Override

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/AbstractGseTaskCommand.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/AbstractGseTaskCommand.java
@@ -37,9 +37,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.cloud.sleuth.Tracer;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * GSE 任务命令基础实现
  */
@@ -110,32 +107,6 @@ public abstract class AbstractGseTaskCommand implements GseTaskCommand {
         this.executeCount = gseTask.getExecuteCount();
         this.batch = gseTask.getBatch();
         this.gseTaskUniqueName = gseTask.getTaskUniqueName();
-    }
-
-    /**
-     * 生成GSE trace 信息
-     */
-    protected Map<String, String> buildGSETraceInfo() {
-        // 捕获所有异常，避免影响任务下发主流程
-        Map<String, String> traceInfoMap = new HashMap<>();
-        try {
-            traceInfoMap.put("CALLER_NAME", "JOB");
-            traceInfoMap.put("JOB_ID", stepInstance.getTaskInstanceId().toString());
-            traceInfoMap.put("STEP_ID", stepInstance.getId().toString());
-            traceInfoMap.put("EXECUTE_COUNT", String.valueOf(stepInstance.getExecuteCount()));
-            traceInfoMap.put("JOB_BIZ_ID", taskInstance.getAppId().toString());
-            if (tracer != null) {
-                traceInfoMap.put("REQUEST_ID", tracer.currentSpan().context().traceId());
-            }
-            if (StringUtils.isNotEmpty(taskInstance.getAppCode())) {
-                traceInfoMap.put("APP_CODE", taskInstance.getAppCode());
-            }
-            traceInfoMap.put("CALLER_IP", agentService.getLocalAgentHost().getIp());
-            traceInfoMap.put("TASK_ACCOUNT", stepInstance.getOperator());
-        } catch (Throwable e) {
-            log.error("Build trace info map for gse failed");
-        }
-        return traceInfoMap;
     }
 
     /**

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/listener/ResultHandleResumeListener.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/listener/ResultHandleResumeListener.java
@@ -45,7 +45,6 @@ import com.tencent.bk.job.execute.model.AgentTaskDTO;
 import com.tencent.bk.job.execute.model.GseTaskDTO;
 import com.tencent.bk.job.execute.model.StepInstanceDTO;
 import com.tencent.bk.job.execute.model.TaskInstanceDTO;
-import com.tencent.bk.job.execute.service.AgentService;
 import com.tencent.bk.job.execute.service.FileAgentTaskService;
 import com.tencent.bk.job.execute.service.GseTaskService;
 import com.tencent.bk.job.execute.service.LogService;
@@ -84,8 +83,6 @@ public class ResultHandleResumeListener {
 
     private final StorageSystemConfig storageSystemConfig;
 
-    private final AgentService agentService;
-
     private final LogService logService;
 
     private final StepInstanceVariableValueService stepInstanceVariableValueService;
@@ -109,7 +106,6 @@ public class ResultHandleResumeListener {
                                       TaskInstanceVariableService taskInstanceVariableService,
                                       GseTaskService gseTaskService,
                                       StorageSystemConfig storageSystemConfig,
-                                      AgentService agentService,
                                       LogService logService,
                                       StepInstanceVariableValueService stepInstanceVariableValueService,
                                       TaskExecuteMQEventDispatcher taskExecuteMQEventDispatcher,
@@ -124,7 +120,6 @@ public class ResultHandleResumeListener {
         this.taskInstanceVariableService = taskInstanceVariableService;
         this.gseTaskService = gseTaskService;
         this.storageSystemConfig = storageSystemConfig;
-        this.agentService = agentService;
         this.logService = logService;
         this.stepInstanceVariableValueService = stepInstanceVariableValueService;
         this.taskExecuteMQEventDispatcher = taskExecuteMQEventDispatcher;
@@ -211,7 +206,6 @@ public class ResultHandleResumeListener {
                                 GseTaskDTO gseTask,
                                 String requestId) {
         Set<JobFile> sendFiles = JobSrcFileUtils.parseSrcFiles(stepInstance,
-            agentService.getLocalAgentHost(),
             storageSystemConfig.getJobStorageRootPath());
         String targetDir = FilePathUtils.standardizedDirPath(stepInstance.getResolvedFileTargetPath());
         Map<JobFile, FileDest> srcAndDestMap = JobSrcFileUtils.buildSourceDestPathMapping(

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/local/LocalFilePrepareService.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/local/LocalFilePrepareService.java
@@ -26,11 +26,13 @@ package com.tencent.bk.job.execute.engine.prepare.local;
 
 import com.tencent.bk.job.common.artifactory.sdk.ArtifactoryClient;
 import com.tencent.bk.job.common.constant.JobConstants;
+import com.tencent.bk.job.common.gse.util.AgentUtils;
 import com.tencent.bk.job.execute.config.ArtifactoryConfig;
 import com.tencent.bk.job.execute.config.LocalFileConfigForExecute;
 import com.tencent.bk.job.execute.config.StorageSystemConfig;
 import com.tencent.bk.job.execute.engine.prepare.JobTaskContext;
 import com.tencent.bk.job.execute.model.FileSourceDTO;
+import com.tencent.bk.job.execute.model.ServersDTO;
 import com.tencent.bk.job.execute.model.StepInstanceBaseDTO;
 import com.tencent.bk.job.execute.model.StepInstanceDTO;
 import com.tencent.bk.job.execute.service.AgentService;
@@ -115,9 +117,17 @@ public class LocalFilePrepareService {
     }
 
     private void fillLocalFileSourceHost(List<FileSourceDTO> fileSourceList, StepInstanceBaseDTO stepInstance) {
+        boolean isGseV1Task = stepInstance.getTargetServers().getIpList().stream()
+            .anyMatch(host -> AgentUtils.isGseV1AgentId(host.getAgentId()));
         fileSourceList.forEach(fileSourceDTO -> {
             if (fileSourceDTO.getFileType() == TaskFileTypeEnum.LOCAL.getType() || fileSourceDTO.isLocalUpload()) {
-                fileSourceDTO.setServers(agentService.getLocalServersDTO());
+                // 如果目标Agent是GSE V1, 那么源Agent也必须要GSE1.0 Agent，设置agentId={云区域:ip}
+                ServersDTO localHost = agentService.getLocalServersDTO().clone();
+                if (isGseV1Task) {
+                    localHost.getIpList().forEach(host -> host.setAgentId(host.toCloudIp()));
+                    localHost.getStaticIpList().forEach(host -> host.setAgentId(host.toCloudIp()));
+                }
+                fileSourceDTO.setServers(localHost);
             }
         });
         // 更新本地文件任务内容

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/util/JobSrcFileUtils.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/util/JobSrcFileUtils.java
@@ -35,6 +35,7 @@ import com.tencent.bk.job.execute.model.FileSourceDTO;
 import com.tencent.bk.job.execute.model.ServersDTO;
 import com.tencent.bk.job.execute.model.StepInstanceDTO;
 import com.tencent.bk.job.manage.common.consts.task.TaskFileTypeEnum;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -103,11 +104,10 @@ public class JobSrcFileUtils {
      * 从步骤解析源文件，处理服务器文件、本地文件、第三方源文件的差异，统一为IP+Path信息
      *
      * @param stepInstance      步骤
-     * @param localHost         job local host
      * @param jobStorageRootDir job共享存储根目录
      * @return 多个要分发的源文件信息集合
      */
-    public static Set<JobFile> parseSrcFiles(StepInstanceDTO stepInstance, HostDTO localHost,
+    public static Set<JobFile> parseSrcFiles(StepInstanceDTO stepInstance,
                                              String jobStorageRootDir) {
         Set<JobFile> sendFiles = Sets.newHashSet();
         for (FileSourceDTO fileSource : stepInstance.getFileSourceList()) {
@@ -152,17 +152,13 @@ public class JobSrcFileUtils {
                         + fileNameAndPath.getLeft();
                     String fileName = fileNameAndPath.getRight();
                     ServersDTO servers = fileSource.getServers();
-                    if (servers != null && servers.getIpList() != null && !servers.getIpList().isEmpty()) {
+                    if (servers != null && CollectionUtils.isNotEmpty(servers.getIpList())) {
                         List<HostDTO> ipList = servers.getIpList();
                         for (HostDTO hostDTO : ipList) {
                             sendFiles.add(new JobFile(TaskFileTypeEnum.LOCAL, hostDTO, file.getFilePath(), dir,
                                 fileName, "root", null,
                                 FilePathUtils.parseDirAndFileName(file.getFilePath()).getRight()));
                         }
-                    } else {
-                        sendFiles.add(new JobFile(TaskFileTypeEnum.LOCAL, localHost, file.getFilePath(), dir,
-                            fileName, "root", null,
-                            FilePathUtils.parseDirAndFileName(file.getFilePath()).getRight()));
                     }
                 }
             } else if (fileSource.getFileType() == TaskFileTypeEnum.BASE64_FILE.getType()) {

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/AgentService.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/AgentService.java
@@ -27,8 +27,17 @@ package com.tencent.bk.job.execute.service;
 import com.tencent.bk.job.common.model.dto.HostDTO;
 import com.tencent.bk.job.execute.model.ServersDTO;
 
+/**
+ * Agent 相关服务
+ */
 public interface AgentService {
+    /**
+     * 获取本地主机的Agent
+     */
     HostDTO getLocalAgentHost();
 
+    /**
+     * 获取本地主机的Agent
+     */
     ServersDTO getLocalServersDTO();
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/AgentServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/AgentServiceImpl.java
@@ -192,9 +192,11 @@ public class AgentServiceImpl implements AgentService {
     private ServiceHostDTO findOneAliveHost(Collection<ServiceHostDTO> serviceHosts) {
         Map<String, ServiceHostDTO> agentIdToHostMap = new HashMap<>();
 
-        serviceHosts.forEach(serviceHost -> {
-            agentIdToHostMap.put(serviceHost.getFinalAgentId(), serviceHost);
-        });
+        serviceHosts.forEach(serviceHost -> agentIdToHostMap.put(
+            StringUtils.isNotEmpty(serviceHost.getAgentId()) ? serviceHost.getAgentId()
+                : serviceHost.getCloudIp(),
+            serviceHost)
+        );
         Map<String, Boolean> agentStatusMap =
             agentStateClient.batchGetAgentAliveStatus(new ArrayList<>(agentIdToHostMap.keySet()));
 
@@ -220,7 +222,7 @@ public class AgentServiceImpl implements AgentService {
         result.setBkCloudId(host.getCloudAreaId());
         result.setIp(host.getIp());
         result.setIpv6(host.getIpv6());
-        result.setAgentId(host.getFinalAgentId());
+        result.setAgentId(host.getAgentId());
         return result;
     }
 

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/inner/ServiceHostDTO.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/inner/ServiceHostDTO.java
@@ -33,7 +33,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * 主机
@@ -83,14 +82,6 @@ public class ServiceHostDTO {
     @JsonIgnore
     public String getCloudIp() {
         return cloudAreaId + ":" + ip;
-    }
-
-    @JsonIgnore
-    public String getFinalAgentId() {
-        if (StringUtils.isNotBlank(agentId)) {
-            return agentId;
-        }
-        return getCloudIp();
     }
 
     public static ServiceHostDTO fromApplicationHostDTO(ApplicationHostDTO host) {

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/HostEventsHandler.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/HostEventsHandler.java
@@ -28,7 +28,6 @@ import com.tencent.bk.job.common.cc.model.req.ResourceWatchReq;
 import com.tencent.bk.job.common.cc.model.result.HostEventDetail;
 import com.tencent.bk.job.common.cc.model.result.ResourceEvent;
 import com.tencent.bk.job.common.constant.JobConstants;
-import com.tencent.bk.job.common.gse.constants.AgentStatusEnum;
 import com.tencent.bk.job.common.gse.service.AgentStateClient;
 import com.tencent.bk.job.common.gse.v2.model.resp.AgentState;
 import com.tencent.bk.job.common.model.dto.ApplicationHostDTO;
@@ -37,15 +36,10 @@ import com.tencent.bk.job.manage.dao.ApplicationHostDAO;
 import com.tencent.bk.job.manage.manager.host.HostCache;
 import com.tencent.bk.job.manage.service.ApplicationService;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.helpers.FormattingTuple;
 import org.slf4j.helpers.MessageFormatter;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 
 @Slf4j
@@ -109,51 +103,12 @@ public class HostEventsHandler extends EventsHandler<HostEventDetail> {
         }
     }
 
-    private List<String> buildAgentIdByMultiIp(Long cloudId, String multiIp) {
-        if (StringUtils.isBlank(multiIp)) {
-            return Collections.emptyList();
-        }
-        String[] ipArr = multiIp.split(",");
-        List<String> agentIdList = new ArrayList<>();
-        for (String ip : ipArr) {
-            agentIdList.add(cloudId + ":" + ip);
-        }
-        return agentIdList;
-    }
-
     private void updateIpAndAgentStatus(ApplicationHostDTO hostInfoDTO) {
-        if (StringUtils.isNotBlank(hostInfoDTO.getAgentId())) {
-            AgentState agentState = agentStateClient.getAgentState(hostInfoDTO.getAgentId());
-            if (agentState != null) {
-                hostInfoDTO.setGseAgentStatus(agentState.getStatusCode());
-            }
-        } else {
-            // 处理多IP的情况
-            String multiIp = hostInfoDTO.getDisplayIp();
-            List<String> agentIdList = buildAgentIdByMultiIp(hostInfoDTO.getCloudAreaId(), multiIp);
-            if (CollectionUtils.isEmpty(agentIdList)) {
-                return;
-            }
-            Map<String, AgentState> agentStateMap = agentStateClient.batchGetAgentState(agentIdList);
-            String validAgentId = agentIdList.get(0);
-            AgentState validAgentState = agentStateMap.get(validAgentId);
-            for (Map.Entry<String, AgentState> entry : agentStateMap.entrySet()) {
-                String agentId = entry.getKey();
-                AgentState agentState = entry.getValue();
-                if (AgentStatusEnum.isAgentAlive(agentState)) {
-                    validAgentId = agentId;
-                    validAgentState = agentState;
-                    break;
-                }
-            }
-            if (!AgentStatusEnum.isAgentAlive(validAgentState)) {
-                log.warn("cannot find agent alive of multiIp:{}", multiIp);
-                return;
-            }
-            hostInfoDTO.setIp(validAgentId.split(":")[1]);
-            if (validAgentState != null) {
-                hostInfoDTO.setGseAgentStatus(validAgentState.getStatusCode());
-            }
+        String agentId = StringUtils.isNotBlank(hostInfoDTO.getAgentId()) ?
+            hostInfoDTO.getAgentId() : hostInfoDTO.getCloudIp();
+        AgentState agentState = agentStateClient.getAgentState(agentId);
+        if (agentState != null) {
+            hostInfoDTO.setGseAgentStatus(agentState.getStatusCode());
         }
     }
 

--- a/support-files/kubernetes/charts/bk-job/VALUES_LOG.md
+++ b/support-files/kubernetes/charts/bk-job/VALUES_LOG.md
@@ -1,6 +1,7 @@
 # chart values 更新日志
 ## 0.4.0-beta.47
 1.增加特性开关相关配置
+
 ```shell script
 ## job-file-gateway文件网关服务配置
 job:
@@ -22,7 +23,16 @@ job:
         params: {}
 ```
 
+2. 新增GSE1.0 控制开关
+
+```
+gse:
+  # 是否启用GSE1.0
+  enabled: true
+```
+
 ## 0.3.0-rc.46
+
 1.增加服务启动顺序控制相关配置
 
 ```shell script

--- a/support-files/kubernetes/charts/bk-job/templates/configmap-common.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/configmap-common.yaml
@@ -38,7 +38,6 @@ data:
         url: {{ .Values.bkGseApiGatewayUrl }}
     gse:
       enabled: {{ .Values.gse.enabled }}
-      version: {{ .Values.gse.version }}
       cache:
         apiserver:
           host: {{ .Values.gse.cacheApiServer.host }}

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -415,8 +415,8 @@ bkGseApiGatewayUrl: "http://bkapi.example.com"
 
 ## 蓝鲸GSE参数配置
 gse:
-  # Job 对接的 GSE 版本 (v1/v2)
-  version: "v2"
+  # 是否启用GSE1.0
+  enabled: true
   # 已存在的Tls证书Secret名称
   existingTlsSecret: ""
   # Agent状态查询接口相关配置

--- a/support-files/templates/#etc#job#job-common#application.yml
+++ b/support-files/templates/#etc#job#job-common#application.yml
@@ -25,6 +25,7 @@ esb:
   service:
     url: __BK_PAAS_PRIVATE_URL__
 gse:
+  enabled: true
   cache:
     apiserver:
       host: __BK_GSE_CACHE_APISERVER_HOST__


### PR DESCRIPTION
1. 多ip主机，直接使用第一个ip作为主ip，不再根据云区域+ip查询agent状态进行判定（ipv6版本不再使用ip与gse交互，统一使用bk_agent_id,这个判定就没有意义了)
2. 优化批量查询agent状态。如果有bk_agent_id，那么查询GSE2.0 Agent状态；如果没有，那么通过{云区域:ip}的方式查询GSE1.0 Agent状态
3. 优化本地文件分发代码，设置本地文件源的主机信息前置到LocalFilePrepareService的文件准备阶段
4. 文件分发，根据目标主机使用的agent版本(根据agent_id判断)来确定源agent的版本
5. 新增gse.enabled配置，用于控制是否启用GSE1.0