### PR TITLE
feature: Job对接GSE1.0/2.0支持灰度 #1602

### DIFF
--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/GseClient.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/GseClient.java
@@ -9,6 +9,7 @@ import com.tencent.bk.job.common.gse.v2.model.ExecuteScriptRequest;
 import com.tencent.bk.job.common.gse.v2.model.FileTaskResult;
 import com.tencent.bk.job.common.gse.v2.model.GetExecuteScriptResultRequest;
 import com.tencent.bk.job.common.gse.v2.model.GetTransferFileResultRequest;
+import com.tencent.bk.job.common.gse.v2.model.GseReq;
 import com.tencent.bk.job.common.gse.v2.model.GseTaskResponse;
 import com.tencent.bk.job.common.gse.v2.model.ScriptTaskResult;
 import com.tencent.bk.job.common.gse.v2.model.TerminateGseTaskRequest;
@@ -27,20 +28,38 @@ import java.util.List;
 public class GseClient implements IGseClient {
 
     private final GseV1ApiClient gseV1ApiClient;
-    private final GseV2ApiClient gseV2APIClient;
+    private final GseV2ApiClient gseV2ApiClient;
 
 
     public GseClient(@Autowired(required = false) GseV1ApiClient gseV1ApiClient,
-                     @Autowired(required = false) GseV2ApiClient gseV2APIClient) {
+                     @Autowired(required = false) GseV2ApiClient gseV2ApiClient) {
         this.gseV1ApiClient = gseV1ApiClient;
-        this.gseV2APIClient = gseV2APIClient;
-        log.info("Init gseClient, gseV1ApiClient: {}, gseV2APIClient: {}", gseV1ApiClient, gseV2APIClient);
+        this.gseV2ApiClient = gseV2ApiClient;
+        log.info("Init gseClient, gseV1ApiClient: {}, gseV2ApiClient: {}", gseV1ApiClient, gseV2ApiClient);
     }
 
 
     @Override
     public GseTaskResponse asyncExecuteScript(ExecuteScriptRequest request) {
-        return chooseGseApiClientByAgentId(request.getAgents().get(0).getAgentId()).asyncExecuteScript(request);
+        return chooseGseApiClientGseTaskVersion(request).asyncExecuteScript(request);
+    }
+
+    private IGseClient chooseGseApiClientGseTaskVersion(GseReq gseReq) {
+        if (gseReq.isGseV2Task()) {
+            return gseV2ApiClient;
+        } else {
+            return gseV1ApiClient;
+        }
+    }
+
+    @Override
+    public ScriptTaskResult getExecuteScriptResult(GetExecuteScriptResultRequest request) {
+        return chooseGseApiClientGseTaskVersion(request).getExecuteScriptResult(request);
+    }
+
+    @Override
+    public List<AgentState> listAgentState(ListAgentStateReq req) {
+        return chooseGseApiClientByAgentId(req.getAgentIdList().get(0)).listAgentState(req);
     }
 
     private IGseClient chooseGseApiClientByAgentId(String agentId) {
@@ -53,46 +72,27 @@ public class GseClient implements IGseClient {
             return gseV1ApiClient;
         } else {
             log.debug("Choose GseV2ApiClient, agentId: {}", agentId);
-            return gseV2APIClient;
+            return gseV2ApiClient;
         }
-    }
-
-    private IGseClient chooseGseApiClientByGseTaskId(String gseTaskId) {
-        if (gseTaskId.startsWith("GSE:V2")) {
-            return gseV2APIClient;
-        } else {
-            return gseV1ApiClient;
-        }
-    }
-
-    @Override
-    public ScriptTaskResult getExecuteScriptResult(GetExecuteScriptResultRequest request) {
-        return chooseGseApiClientByGseTaskId(request.getTaskId()).getExecuteScriptResult(request);
-    }
-
-    @Override
-    public List<AgentState> listAgentState(ListAgentStateReq req) {
-        return chooseGseApiClientByAgentId(req.getAgentIdList().get(0)).listAgentState(req);
     }
 
     @Override
     public GseTaskResponse asyncTransferFile(TransferFileRequest request) {
-        return chooseGseApiClientByAgentId(request.getTasks().get(0).getTarget().getAgents().get(0).getAgentId())
-            .asyncTransferFile(request);
+        return chooseGseApiClientGseTaskVersion(request).asyncTransferFile(request);
     }
 
     @Override
     public FileTaskResult getTransferFileResult(GetTransferFileResultRequest request) {
-        return chooseGseApiClientByGseTaskId(request.getTaskId()).getTransferFileResult(request);
+        return chooseGseApiClientGseTaskVersion(request).getTransferFileResult(request);
     }
 
     @Override
     public GseTaskResponse terminateGseFileTask(TerminateGseTaskRequest request) {
-        return chooseGseApiClientByGseTaskId(request.getTaskId()).terminateGseFileTask(request);
+        return chooseGseApiClientGseTaskVersion(request).terminateGseFileTask(request);
     }
 
     @Override
     public GseTaskResponse terminateGseScriptTask(TerminateGseTaskRequest request) {
-        return chooseGseApiClientByGseTaskId(request.getTaskId()).terminateGseScriptTask(request);
+        return chooseGseApiClientGseTaskVersion(request).terminateGseScriptTask(request);
     }
 }

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/GseClient.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/GseClient.java
@@ -41,10 +41,10 @@ public class GseClient implements IGseClient {
 
     @Override
     public GseTaskResponse asyncExecuteScript(ExecuteScriptRequest request) {
-        return chooseGseApiClientGseTaskVersion(request).asyncExecuteScript(request);
+        return chooseGseApiClientByGseTaskVersion(request).asyncExecuteScript(request);
     }
 
-    private IGseClient chooseGseApiClientGseTaskVersion(GseReq gseReq) {
+    private IGseClient chooseGseApiClientByGseTaskVersion(GseReq gseReq) {
         if (gseReq.isGseV2Task()) {
             return gseV2ApiClient;
         } else {
@@ -54,7 +54,7 @@ public class GseClient implements IGseClient {
 
     @Override
     public ScriptTaskResult getExecuteScriptResult(GetExecuteScriptResultRequest request) {
-        return chooseGseApiClientGseTaskVersion(request).getExecuteScriptResult(request);
+        return chooseGseApiClientByGseTaskVersion(request).getExecuteScriptResult(request);
     }
 
     @Override
@@ -78,21 +78,21 @@ public class GseClient implements IGseClient {
 
     @Override
     public GseTaskResponse asyncTransferFile(TransferFileRequest request) {
-        return chooseGseApiClientGseTaskVersion(request).asyncTransferFile(request);
+        return chooseGseApiClientByGseTaskVersion(request).asyncTransferFile(request);
     }
 
     @Override
     public FileTaskResult getTransferFileResult(GetTransferFileResultRequest request) {
-        return chooseGseApiClientGseTaskVersion(request).getTransferFileResult(request);
+        return chooseGseApiClientByGseTaskVersion(request).getTransferFileResult(request);
     }
 
     @Override
     public GseTaskResponse terminateGseFileTask(TerminateGseTaskRequest request) {
-        return chooseGseApiClientGseTaskVersion(request).terminateGseFileTask(request);
+        return chooseGseApiClientByGseTaskVersion(request).terminateGseFileTask(request);
     }
 
     @Override
     public GseTaskResponse terminateGseScriptTask(TerminateGseTaskRequest request) {
-        return chooseGseApiClientGseTaskVersion(request).terminateGseScriptTask(request);
+        return chooseGseApiClientByGseTaskVersion(request).terminateGseScriptTask(request);
     }
 }

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/ExecuteScriptRequest.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/ExecuteScriptRequest.java
@@ -2,6 +2,7 @@ package com.tencent.bk.job.common.gse.v2.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -9,8 +10,9 @@ import java.util.List;
 /**
  * GSE - 下发脚本任务请求
  */
+@EqualsAndHashCode(callSuper = true)
 @Data
-public class ExecuteScriptRequest {
+public class ExecuteScriptRequest extends GseReq {
     /**
      * 目标Agent
      */

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/GetExecuteScriptResultRequest.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/GetExecuteScriptResultRequest.java
@@ -59,7 +59,6 @@ public class GetExecuteScriptResultRequest extends GseReq {
         AgentTask agentTask = new AgentTask();
         agentTask.setAgentId(agentId);
         AtomicTask atomicTask = new AtomicTask();
-        ;
         atomicTask.setAtomicTaskId(atomicTaskId);
         atomicTask.setOffset(offset);
         agentTask.setAtomicTasks(Collections.singletonList(atomicTask));

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/GetExecuteScriptResultRequest.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/GetExecuteScriptResultRequest.java
@@ -2,6 +2,7 @@ package com.tencent.bk.job.common.gse.v2.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -11,7 +12,8 @@ import java.util.List;
  * GSE - 查询脚本任务的执行结果请求
  */
 @Data
-public class GetExecuteScriptResultRequest {
+@EqualsAndHashCode(callSuper = true)
+public class GetExecuteScriptResultRequest extends GseReq {
     /**
      * GSE 任务ID
      */
@@ -56,7 +58,8 @@ public class GetExecuteScriptResultRequest {
     public void addAgentTaskQuery(String agentId, Integer atomicTaskId, int offset) {
         AgentTask agentTask = new AgentTask();
         agentTask.setAgentId(agentId);
-        AtomicTask atomicTask = new AtomicTask();;
+        AtomicTask atomicTask = new AtomicTask();
+        ;
         atomicTask.setAtomicTaskId(atomicTaskId);
         atomicTask.setOffset(offset);
         agentTask.setAtomicTasks(Collections.singletonList(atomicTask));

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/GetTransferFileResultRequest.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/GetTransferFileResultRequest.java
@@ -2,6 +2,7 @@ package com.tencent.bk.job.common.gse.v2.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
@@ -11,7 +12,8 @@ import java.util.List;
  */
 @Data
 @NoArgsConstructor
-public class GetTransferFileResultRequest {
+@EqualsAndHashCode(callSuper = true)
+public class GetTransferFileResultRequest extends GseReq {
     /**
      * GSE 任务ID
      */

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/GseReq.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/GseReq.java
@@ -1,0 +1,19 @@
+package com.tencent.bk.job.common.gse.v2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Data;
+
+/**
+ * GSE 请求基础类
+ */
+@Data
+public class GseReq {
+
+
+    /**
+     * 是否是GSE V2 Task; 根据gseV2Task判断请求GSE V1/v2
+     */
+    @JsonIgnore
+    private boolean gseV2Task;
+
+}

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/TerminateGseTaskRequest.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/TerminateGseTaskRequest.java
@@ -1,7 +1,9 @@
 package com.tencent.bk.job.common.gse.v2.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
@@ -12,7 +14,8 @@ import java.util.List;
  */
 @Data
 @NoArgsConstructor
-public class TerminateGseTaskRequest {
+@EqualsAndHashCode(callSuper = true)
+public class TerminateGseTaskRequest extends GseReq {
     /**
      * GSE 任务ID
      */
@@ -24,6 +27,12 @@ public class TerminateGseTaskRequest {
      */
     @JsonProperty("agent_id_list")
     private List<String> agentIds = new ArrayList<>();
+
+    /**
+     * 是否是GSE V2 Task; 根据gseV2Task判断请求GSE V1/v2
+     */
+    @JsonIgnore
+    private boolean gseV2Task;
 
     public TerminateGseTaskRequest(String taskId, List<String> agentIds) {
         this.taskId = taskId;

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/TransferFileRequest.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/TransferFileRequest.java
@@ -2,6 +2,7 @@ package com.tencent.bk.job.common.gse.v2.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -9,8 +10,9 @@ import java.util.List;
 /**
  * GSE - 下发文件任务请求
  */
+@EqualsAndHashCode(callSuper = true)
 @Data
-public class TransferFileRequest {
+public class TransferFileRequest extends GseReq {
 
     /**
      * 文件任务

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/AbstractGseTaskCommand.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/AbstractGseTaskCommand.java
@@ -82,6 +82,10 @@ public abstract class AbstractGseTaskCommand implements GseTaskCommand {
      * GSE 任务唯一名称
      */
     protected String gseTaskUniqueName;
+    /**
+     * 是否是GSE V2 Task
+     */
+    protected boolean gseV2Task;
 
 
     public AbstractGseTaskCommand(AgentService agentService,
@@ -101,6 +105,7 @@ public abstract class AbstractGseTaskCommand implements GseTaskCommand {
         this.gseClient = gseClient;
         this.taskInstance = taskInstance;
         this.stepInstance = stepInstance;
+        this.gseV2Task = stepInstance.isTargetGseV2Agent();
         this.gseTask = gseTask;
         this.taskInstanceId = taskInstance.getId();
         this.stepInstanceId = gseTask.getStepInstanceId();

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/FileGseTaskStartCommand.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/FileGseTaskStartCommand.java
@@ -264,6 +264,7 @@ public class FileGseTaskStartCommand extends AbstractGseTaskStartCommand {
     @Override
     protected GseTaskResponse startGseTask() {
         TransferFileRequest request = new TransferFileRequest();
+        request.setGseV2Task(gseV2Task);
 
         // 账号信息查询与填充
         AccountDTO accountInfo = accountService.getAccount(stepInstance.getAccountId(), AccountCategoryEnum.SYSTEM,

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/SQLScriptGseTaskStartCommand.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/SQLScriptGseTaskStartCommand.java
@@ -188,7 +188,9 @@ public class SQLScriptGseTaskStartCommand extends ScriptGseTaskStartCommand {
         builder.addScriptTask(agentList, scriptFilePath, publicScriptName, buildRunSqlShellParams(sqlScriptFileName),
             timeout);
 
-        return builder.build();
+        ExecuteScriptRequest request = builder.build();
+        request.setGseV2Task(gseV2Task);
+        return request;
     }
 
     private String buildRunSqlShellParams(String sqlScriptFileName) {

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/ScriptGseTaskStartCommand.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/ScriptGseTaskStartCommand.java
@@ -184,6 +184,7 @@ public class ScriptGseTaskStartCommand extends AbstractGseTaskStartCommand {
         } else {
             request = buildRequestWithoutAnyParam(stepInstance);
         }
+        request.setGseV2Task(gseV2Task);
 
         return request;
     }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/ScriptGseTaskStopCommand.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/ScriptGseTaskStopCommand.java
@@ -76,6 +76,7 @@ public class ScriptGseTaskStopCommand extends AbstractGseTaskCommand {
 
 
         TerminateGseTaskRequest request = new TerminateGseTaskRequest(gseTask.getGseTaskId(), terminateAgentIds);
+        request.setGseV2Task(gseV2Task);
         GseTaskResponse gseTaskResponse = gseClient.terminateGseScriptTask(request);
         if (GseTaskResponse.ERROR_CODE_SUCCESS != gseTaskResponse.getErrorCode()) {
             log.error("Terminate gse task failed! gseTask: {}", gseTaskUniqueName);

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/local/LocalFilePrepareService.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/local/LocalFilePrepareService.java
@@ -26,7 +26,6 @@ package com.tencent.bk.job.execute.engine.prepare.local;
 
 import com.tencent.bk.job.common.artifactory.sdk.ArtifactoryClient;
 import com.tencent.bk.job.common.constant.JobConstants;
-import com.tencent.bk.job.common.gse.util.AgentUtils;
 import com.tencent.bk.job.execute.config.ArtifactoryConfig;
 import com.tencent.bk.job.execute.config.LocalFileConfigForExecute;
 import com.tencent.bk.job.execute.config.StorageSystemConfig;
@@ -117,13 +116,12 @@ public class LocalFilePrepareService {
     }
 
     private void fillLocalFileSourceHost(List<FileSourceDTO> fileSourceList, StepInstanceBaseDTO stepInstance) {
-        boolean isGseV1Task = stepInstance.getTargetServers().getIpList().stream()
-            .anyMatch(host -> AgentUtils.isGseV1AgentId(host.getAgentId()));
+        boolean isGseV2Task = stepInstance.isTargetGseV2Agent();
         fileSourceList.forEach(fileSourceDTO -> {
             if (fileSourceDTO.getFileType() == TaskFileTypeEnum.LOCAL.getType() || fileSourceDTO.isLocalUpload()) {
-                // 如果目标Agent是GSE V1, 那么源Agent也必须要GSE1.0 Agent，设置agentId={云区域:ip}
                 ServersDTO localHost = agentService.getLocalServersDTO().clone();
-                if (isGseV1Task) {
+                if (!isGseV2Task) {
+                    // 如果目标Agent是GSE V1, 那么源Agent也必须要GSE1.0 Agent，设置agentId={云区域:ip}
                     localHost.getIpList().forEach(host -> host.setAgentId(host.toCloudIp()));
                     localHost.getStaticIpList().forEach(host -> host.setAgentId(host.toCloudIp()));
                 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/AbstractResultHandleTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/AbstractResultHandleTask.java
@@ -203,6 +203,10 @@ public abstract class AbstractResultHandleTask<T> implements ContinuousScheduled
      * GSE任务是否处于终止状态
      */
     private volatile boolean isGseTaskTerminating = false;
+    /**
+     * 是否是GSE V2 TASK
+     */
+    protected boolean gseV2Task;
     // ---------------- task lifecycle properties --------------------
 
 
@@ -238,15 +242,14 @@ public abstract class AbstractResultHandleTask<T> implements ContinuousScheduled
         this.taskInstance = taskInstance;
         this.taskInstanceId = taskInstance.getId();
         this.stepInstance = stepInstance;
+        this.gseV2Task = stepInstance.isTargetGseV2Agent();
         this.appId = stepInstance.getAppId();
         this.stepInstanceId = stepInstance.getId();
         this.taskVariablesAnalyzeResult = taskVariablesAnalyzeResult;
         this.targetAgentTasks = targetAgentTasks;
         this.gseTask = gseTask;
 
-        targetAgentTasks.values().forEach(agentTask -> {
-            this.targetAgentIds.add(agentTask.getAgentId());
-        });
+        targetAgentTasks.values().forEach(agentTask -> this.targetAgentIds.add(agentTask.getAgentId()));
         this.notStartedTargetAgentIds.addAll(targetAgentIds);
 
         this.agentIdHostMap = stepInstanceService.computeStepHosts(stepInstance,

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/FileResultHandleTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/FileResultHandleTask.java
@@ -238,6 +238,7 @@ public class FileResultHandleTask extends AbstractResultHandleTask<FileTaskResul
     @Override
     GseLogBatchPullResult<FileTaskResult> pullGseTaskResultInBatches() {
         GetTransferFileResultRequest request = new GetTransferFileResultRequest();
+        request.setGseV2Task(gseV2Task);
         request.setTaskId(gseTask.getGseTaskId());
 
         if (CollectionUtils.isNotEmpty(this.analyseFinishedSourceAgentIds)

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/ScriptResultHandleTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/ScriptResultHandleTask.java
@@ -233,6 +233,7 @@ public class ScriptResultHandleTask extends AbstractResultHandleTask<ScriptTaskR
 
     private ScriptTaskResult pullGseTaskResult(List<String> agentIds) {
         GetExecuteScriptResultRequest request = new GetExecuteScriptResultRequest();
+        request.setGseV2Task(gseV2Task);
         request.setTaskId(gseTask.getGseTaskId());
         agentIds.forEach(agentId -> {
             LogPullProgress progress = logPullProgressMap.get(agentId);

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/model/StepInstanceBaseDTO.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/model/StepInstanceBaseDTO.java
@@ -24,6 +24,7 @@
 
 package com.tencent.bk.job.execute.model;
 
+import com.tencent.bk.job.common.gse.util.AgentUtils;
 import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
 import com.tencent.bk.job.execute.common.constants.StepExecuteTypeEnum;
 import com.tencent.bk.job.manage.common.consts.task.TaskStepTypeEnum;
@@ -198,5 +199,14 @@ public class StepInstanceBaseDTO {
             return id.toString();
         }
         return id + "_" + executeCount;
+    }
+
+    /**
+     * 执行目标是否是 GSE V2 Agent
+     */
+    public boolean isTargetGseV2Agent() {
+        boolean isTargetGseV1Agent = this.targetServers.getIpList().stream()
+            .anyMatch(host -> AgentUtils.isGseV1AgentId(host.getAgentId()));
+        return !isTargetGseV1Agent;
     }
 }

--- a/support-files/templates/#etc#job#job-common#application.yml
+++ b/support-files/templates/#etc#job#job-common#application.yml
@@ -24,6 +24,10 @@ app:
 esb:
   service:
     url: __BK_PAAS_PRIVATE_URL__
+# 蓝鲸Api Gateway 配置    
+bkApiGateway:
+  gse:
+    url: __BK_API_GATEWAY_GSE_URL__
 gse:
   enabled: true
   cache:


### PR DESCRIPTION
- 问题
通过thrift API 下发任务给GSE, 由于GSE Server可能是V1/V2, 所以返回的GSE_TASK_ID可能是以"GSE:V2"开头的。如果依赖对GSE_TASK_ID的判断，可能会不准确
- 解决方案
所有调用GSE API的地方，通过目标agent_id来判断任务是属于GSE V1/V2的任务，解耦与GSE_TASK_ID的依赖