### PR TITLE
bugfix: 目标主机为IPv6, 作业执行详情-导出日志的主机ip信息显示为null #1656

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/model/ScriptHostLogContent.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/model/ScriptHostLogContent.java
@@ -24,9 +24,9 @@
 
 package com.tencent.bk.job.execute.model;
 
-import com.tencent.bk.job.common.annotation.CompatibleImplementation;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * 脚本日志内容
@@ -47,10 +47,13 @@ public class ScriptHostLogContent {
      */
     private Long hostId;
     /**
-     * 目标IP
+     * 主机IPv4
      */
-    @CompatibleImplementation(name = "rolling_execute", explain = "兼容字段，后续使用hostId替换", version = "3.7.x")
     private String ip;
+    /**
+     * 主机IPv6
+     */
+    private String ipv6;
     /**
      * 日志内容
      */
@@ -60,13 +63,27 @@ public class ScriptHostLogContent {
      */
     private boolean finished;
 
-    public ScriptHostLogContent(long stepInstanceId, int executeCount, Long hostId,
-                                String ip, String content, boolean finished) {
+    public ScriptHostLogContent(long stepInstanceId,
+                                int executeCount,
+                                Long hostId,
+                                String ip,
+                                String ipv6,
+                                String content,
+                                boolean finished) {
         this.stepInstanceId = stepInstanceId;
         this.executeCount = executeCount;
         this.hostId = hostId;
         this.ip = ip;
         this.content = content;
         this.finished = finished;
+    }
+
+    /**
+     * 获取主机的ip，优先返回ipv4
+     *
+     * @return 主机ipv4/ipv6, ipv4 优先
+     */
+    public String getPrimaryIp() {
+        return StringUtils.isNotEmpty(ip) ? ip : ipv6;
     }
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/LogExportServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/LogExportServiceImpl.java
@@ -226,7 +226,7 @@ public class LogExportServiceImpl implements LogExportService {
                                 if (isGetByHost) {
                                     out.println(log);
                                 } else {
-                                    out.println(scriptHostLogContent.getIp() + " | " + log);
+                                    out.println(scriptHostLogContent.getPrimaryIp() + " | " + log);
                                 }
                             }
                         }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/LogServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/LogServiceImpl.java
@@ -182,7 +182,8 @@ public class LogServiceImpl implements LogService {
             logDTO.getScriptLog().getContent() : "";
         Long hostId = logDTO != null ? logDTO.getHostId() : null;
         String ip = logDTO != null ? logDTO.getIp() : null;
-        return new ScriptHostLogContent(stepInstanceId, executeCount, hostId, ip, scriptContent, isFinished);
+        String ipv6 = logDTO != null ? logDTO.getIpv6() : null;
+        return new ScriptHostLogContent(stepInstanceId, executeCount, hostId, ip, ipv6, scriptContent, isFinished);
     }
 
     @Override
@@ -217,7 +218,7 @@ public class LogServiceImpl implements LogService {
             String scriptContent = logDTO.getScriptLog() != null ?
                 logDTO.getScriptLog().getContent() : "";
             return new ScriptHostLogContent(logDTO.getStepInstanceId(), logDTO.getExecuteCount(), logDTO.getHostId(),
-                logDTO.getIp(), scriptContent, true);
+                logDTO.getIp(), logDTO.getIpv6(), scriptContent, true);
         }).collect(Collectors.toList());
 
     }


### PR DESCRIPTION
#1656 
1. 从job-logsvr获取执行日志后转换为ScriptHostLogContent，新增ipv6字段（写入job-logsvr的日志已经带有hostId/ip/ipv6三个字段)
2. 优先使用ipv4