### PR TITLE
bugfix: 动态分组拉取到的主机信息含有多个IP时接口报错 #1716

### DIFF
--- a/src/backend/commons/cmdb-sdk-model/src/main/java/com/tencent/bk/job/common/cc/model/CcGroupHostPropDTO.java
+++ b/src/backend/commons/cmdb-sdk-model/src/main/java/com/tencent/bk/job/common/cc/model/CcGroupHostPropDTO.java
@@ -24,7 +24,9 @@
 
 package com.tencent.bk.job.common.cc.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.tencent.bk.job.common.util.ip.IpUtils;
 import lombok.Data;
 
 import java.util.List;
@@ -44,9 +46,15 @@ public class CcGroupHostPropDTO {
     @JsonProperty("bk_host_name")
     private String name;
 
+    // 可能为多IP
     @JsonProperty("bk_host_innerip")
-    private String ip;
+    private String innerIp;
 
     @JsonProperty("bk_cloud_id")
     private List<CcCloudIdDTO> cloudIdList;
+
+    @JsonIgnore
+    public String getFirstIp() {
+        return IpUtils.getFirstIpFromMultiIp(innerIp, ",");
+    }
 }

--- a/src/backend/commons/cmdb-sdk-model/src/main/java/com/tencent/bk/job/common/cc/model/CcHostInfoDTO.java
+++ b/src/backend/commons/cmdb-sdk-model/src/main/java/com/tencent/bk/job/common/cc/model/CcHostInfoDTO.java
@@ -24,7 +24,9 @@
 
 package com.tencent.bk.job.common.cc.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.tencent.bk.job.common.util.ip.IpUtils;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -37,11 +39,16 @@ public class CcHostInfoDTO {
     @JsonProperty("bk_host_id")
     private Long hostId;
     @JsonProperty("bk_host_innerip")
-    private String ip;
+    private String innerIp;
     @JsonProperty("bk_host_name")
     private String hostName;
     @JsonProperty("bk_os_name")
     private String os;
     @JsonProperty("bk_cloud_id")
     private Long cloudId;
+
+    @JsonIgnore
+    public String getFirstIp() {
+        return IpUtils.getFirstIpFromMultiIp(innerIp, ",");
+    }
 }

--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BizCmdbClient.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BizCmdbClient.java
@@ -717,7 +717,7 @@ public class BizCmdbClient extends AbstractEsbSdkClient implements IBizCmdbClien
         ApplicationHostDTO ipInfo = new ApplicationHostDTO();
         ipInfo.setHostId(hostInfo.getHostId());
         // 部分从cmdb同步过来的资源没有ip，需要过滤掉
-        if (StringUtils.isBlank(hostInfo.getIp())) {
+        if (StringUtils.isBlank(hostInfo.getInnerIp())) {
             return null;
         }
 
@@ -733,10 +733,12 @@ public class BizCmdbClient extends AbstractEsbSdkClient implements IBizCmdbClien
             return null;
         }
 
+        ipInfo.setDisplayIp(hostInfo.getInnerIp());
+
         if (queryAgentStatusClient != null) {
-            ipInfo.setIp(queryAgentStatusClient.getHostIpByAgentStatus(hostInfo.getIp(), hostInfo.getCloudId()));
+            ipInfo.setIp(queryAgentStatusClient.getHostIpByAgentStatus(hostInfo.getInnerIp(), hostInfo.getCloudId()));
         } else {
-            ipInfo.setIp(hostInfo.getIp());
+            ipInfo.setIp(hostInfo.getFirstIp());
         }
         ipInfo.setBizId(bizId);
         ipInfo.setIpDesc(hostInfo.getHostName());
@@ -859,13 +861,13 @@ public class BizCmdbClient extends AbstractEsbSdkClient implements IBizCmdbClien
                 log.warn(
                     "host(id={},ip={}) does not have cloud area, ignore",
                     ccHostInfo.getHostId(),
-                    ccHostInfo.getIp()
+                    ccHostInfo.getInnerIp()
                 );
-            } else if (StringUtils.isBlank(ccHostInfo.getIp())) {
+            } else if (StringUtils.isBlank(ccHostInfo.getInnerIp())) {
                 log.warn(
                     "host(id={},ip={}) ip invalid, ignore",
                     ccHostInfo.getHostId(),
-                    ccHostInfo.getIp()
+                    ccHostInfo.getInnerIp()
                 );
             } else {
                 ccGroupHostList.add(convertToCcHost(ccHostInfo));
@@ -919,7 +921,7 @@ public class BizCmdbClient extends AbstractEsbSdkClient implements IBizCmdbClien
         CcGroupHostPropDTO ccGroupHostPropDTO = new CcGroupHostPropDTO();
         ccGroupHostPropDTO.setId(ccHostInfo.getHostId());
         ccGroupHostPropDTO.setName(ccHostInfo.getHostName());
-        ccGroupHostPropDTO.setIp(ccHostInfo.getIp());
+        ccGroupHostPropDTO.setInnerIp(ccHostInfo.getInnerIp());
         CcCloudIdDTO ccCloudIdDTO = new CcCloudIdDTO();
         // 仅使用CloudId其余属性未用到，暂不设置
         ccCloudIdDTO.setInstanceId(ccHostInfo.getCloudId());

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/ip/IpUtils.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/ip/IpUtils.java
@@ -35,7 +35,13 @@ import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.UnknownHostException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -51,9 +57,11 @@ public class IpUtils {
      */
     public static final long DEFAULT_CLOUD_ID = 0;
     private static final Pattern IP_PATTERN = Pattern.compile(
-        "\\b((?!\\d\\d\\d)\\d+|1\\d\\d|2[0-4]\\d|25[0-5])\\.((?!\\d\\d\\d)\\d+|1\\d\\d|2[0-4]\\d|25[0-5])\\.((?!\\d\\d\\d)\\d+|1\\d\\d|2[0-4]\\d|25[0-5])\\.((?!\\d\\d\\d)\\d+|1\\d\\d|2[0-4]\\d|25[0-5])\\b");
+        "\\b((?!\\d\\d\\d)\\d+|1\\d\\d|2[0-4]\\d|25[0-5])\\.((?!\\d\\d\\d)\\d+|1\\d\\d|2[0-4]\\d|25[0-5])\\.(" +
+            "(?!\\d\\d\\d)\\d+|1\\d\\d|2[0-4]\\d|25[0-5])\\.((?!\\d\\d\\d)\\d+|1\\d\\d|2[0-4]\\d|25[0-5])\\b");
     private static final Pattern pattern = Pattern.compile(
-        "\\b((?!\\d\\d\\d)\\d+|1\\d\\d|2[0-4]\\d|25[0-5])\\.((?!\\d\\d\\d)\\d+|1\\d\\d|2[0-4]\\d|25[0-5])\\.((?!\\d\\d\\d)\\d+|1\\d\\d|2[0-4]\\d|25[0-5])\\.((?!\\d\\d\\d)\\d+|1\\d\\d|2[0-4]\\d|25[0-5])\\b");
+        "\\b((?!\\d\\d\\d)\\d+|1\\d\\d|2[0-4]\\d|25[0-5])\\.((?!\\d\\d\\d)\\d+|1\\d\\d|2[0-4]\\d|25[0-5])\\.(" +
+            "(?!\\d\\d\\d)\\d+|1\\d\\d|2[0-4]\\d|25[0-5])\\.((?!\\d\\d\\d)\\d+|1\\d\\d|2[0-4]\\d|25[0-5])\\b");
 
     /**
      * 校验云区域:服务器IP
@@ -274,5 +282,22 @@ public class IpUtils {
             ip = "no available ip";
         }
         return ip;
+    }
+
+    /**
+     * 从含有多个IP的字符串中获取首个IP，若multiIp不含有任何IP则直接返回multiIp本身
+     *
+     * @param multiIp   多IP字符串
+     * @param separator 分隔符
+     * @return 首个IP
+     */
+    public static String getFirstIpFromMultiIp(String multiIp, String separator) {
+        if (StringUtils.isBlank(multiIp)) {
+            return multiIp;
+        }
+        if (multiIp.contains(separator)) {
+            return multiIp.split(separator)[0];
+        }
+        return multiIp;
     }
 }

--- a/src/backend/commons/common/src/test/java/com/tencent/bk/job/common/util/IpUtilsTest.java
+++ b/src/backend/commons/common/src/test/java/com/tencent/bk/job/common/util/IpUtilsTest.java
@@ -50,4 +50,13 @@ public class IpUtilsTest {
         String ip = IpUtils.revertIpFromLongStr(ipLongStr);
         assertThat(ip).isEqualTo("127.0.0.1");
     }
+
+    @Test
+    void testGetFirstIpFromMultiIp() {
+        assertThat(IpUtils.getFirstIpFromMultiIp(null, ",")).isNull();
+        assertThat(IpUtils.getFirstIpFromMultiIp("", ",")).isEqualTo("");
+        assertThat(IpUtils.getFirstIpFromMultiIp("192.168.1.1", ",")).isEqualTo("192.168.1.1");
+        assertThat(IpUtils.getFirstIpFromMultiIp("192.168.1.1,", ",")).isEqualTo("192.168.1.1");
+        assertThat(IpUtils.getFirstIpFromMultiIp("192.168.1.1,192.168.1.2", ",")).isEqualTo("192.168.1.1");
+    }
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/HostServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/HostServiceImpl.java
@@ -201,16 +201,16 @@ public class HostServiceImpl implements HostService {
             List<CcCloudIdDTO> hostCloudIdList = hostProp.getCloudIdList();
             if (hostCloudIdList == null || hostCloudIdList.isEmpty()) {
                 log.warn("Get ip by dynamic group id, cmdb return illegal host, skip it!appId={}, groupId={}, " +
-                    "hostIp={}", appId, groupId, hostProp.getIp());
+                    "hostIp={}", appId, groupId, hostProp.getInnerIp());
                 continue;
             }
             CcCloudIdDTO hostCloudId = hostCloudIdList.get(0);
             if (hostCloudId == null) {
                 log.warn("Get ip by dynamic group id, cmdb return illegal host, skip it!appId={}, groupId={}, " +
-                    "hostIp={}", appId, groupId, hostProp.getIp());
+                    "hostIp={}", appId, groupId, hostProp.getInnerIp());
                 continue;
             }
-            IpDTO ip = new IpDTO(hostCloudId.getInstanceId(), hostProp.getIp());
+            IpDTO ip = new IpDTO(hostCloudId.getInstanceId(), hostProp.getFirstIp());
             ips.add(ip);
         }
         log.info("Get hosts by groupId, appId={}, groupId={}, hosts={}", appId, groupId, ips);

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/HostServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/HostServiceImpl.java
@@ -526,7 +526,7 @@ public class HostServiceImpl implements HostService {
             List<String> cloudIpList = new ArrayList<>();
             for (CcGroupHostPropDTO groupHost : ccGroupHostProps) {
                 if (CollectionUtils.isNotEmpty(groupHost.getCloudIdList())) {
-                    cloudIpList.add(groupHost.getCloudIdList().get(0).getInstanceId() + ":" + groupHost.getIp());
+                    cloudIpList.add(groupHost.getCloudIdList().get(0).getInstanceId() + ":" + groupHost.getFirstIp());
                 } else {
                     log.warn("Wrong host info! No cloud area!|{}", groupHost);
                 }


### PR DESCRIPTION
1. 明确区分展示用多IP与单个IP，消除“ip”字段的混淆使用。