### PR TITLE
bugfix: 任务执行详情页面导出日志时不显示文件大小 #1731 

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/LogExportServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/LogExportServiceImpl.java
@@ -28,6 +28,7 @@ import com.tencent.bk.job.common.artifactory.sdk.ArtifactoryClient;
 import com.tencent.bk.job.common.constant.JobConstants;
 import com.tencent.bk.job.common.model.dto.HostDTO;
 import com.tencent.bk.job.common.redis.util.LockUtils;
+import com.tencent.bk.job.common.trace.executors.TraceableExecutorService;
 import com.tencent.bk.job.common.util.BatchUtil;
 import com.tencent.bk.job.common.util.date.DateUtils;
 import com.tencent.bk.job.common.util.file.ZipUtil;
@@ -253,6 +254,7 @@ public class LogExportServiceImpl implements LogExportService {
             } else {
                 FileUtils.deleteQuietly(logFile);
             }
+            long zipFileLength = zipFile.length();
             // 将zip文件上传至制品库
             if (JobConstants.FILE_STORAGE_BACKEND_ARTIFACTORY.equals(logExportConfig.getStorageBackend())) {
                 try {
@@ -275,7 +277,7 @@ public class LogExportServiceImpl implements LogExportService {
             }
             exportJobInfo.setStatus(LogExportStatusEnum.SUCCESS);
             exportJobInfo.setZipFileName(logFileName + ".zip");
-            exportJobInfo.setFileSize(zipFile.length());
+            exportJobInfo.setFileSize(zipFileLength);
             saveExportInfo(exportJobInfo);
         } catch (Exception e) {
             log.warn("Zip log file fail, fileName={}", logFile.getName());


### PR DESCRIPTION
1. 修复bug：在文件被删除前记录大小信息；
2. 重构代码，优化日志打印。